### PR TITLE
feat: Support `aliases gen --binary` option & dependencies commands

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -29,6 +29,14 @@
   version = "v0.16.0"
 
 [[projects]]
+  digest = "1:3a26588bc48b96825977c1b3df964f8fd842cd6860cc26370588d3563433cf11"
+  name = "github.com/google/uuid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d460ce9f8df2e77fb1ba55ca87fafed96c607494"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:0a69a1c0db3591fcefb47f115b224592c8dfa4368b7ba9fae509d5e16cdc95c8"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
@@ -92,6 +100,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/creasty/defaults",
+    "github.com/google/uuid",
     "github.com/sirupsen/logrus",
     "github.com/urfave/cli",
     "gopkg.in/go-playground/validator.v9",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:7f769a7ea697a8e50c8a79a829f53a469e3ca7b8e314434ea9d9a25ca8401cb7"
+  name = "github.com/creasty/defaults"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "a7e48e2230891fc7456c8ab918c424c5b06c3192"
+  version = "v1.2.1"
+
+[[projects]]
   digest = "1:e1ff887e232b2d8f4f7c7db15a5fac7be418025afc4dda53c59c765dbb5aa6b4"
   name = "github.com/go-playground/locales"
   packages = [
@@ -83,6 +91,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/creasty/defaults",
     "github.com/sirupsen/logrus",
     "github.com/urfave/cli",
     "gopkg.in/go-playground/validator.v9",

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A is a tool for resolving command dependencies with containers.
 
 * YAML-based command definition
 * Version of command with environment variable
+* Call another dependent command from the command
 
 ## Install
 
@@ -19,15 +20,35 @@ $ go get github.com/k-kinzal/aliases
 /usr/local/bin/kubectl:
   image: chatwork/kubectl
   tag: 1.11.2
-  interactive: true
-  network: host
   volume:
   - $HOME/.kube:/root/.kube
+  network: host
+
+/usr/local/bin/helmfile:
+  image: chatwork/helmfile
+  tag: 0.36.1-2.10.0
+  volume:
+  - $HOME/.kube:/root/.kube
+  - $HOME/.helm:/root/.helm
+  - $PWD:/helmfile
+  workdir: /helmfile
+  network: host
+  dependencies:
+  - /usr/local/bin/kubectl
 ```
 
 ```
 $ eval $(aliases gen)
 ```
+
+or 
+
+```
+$ eval $(aliases gen --binary)
+```
+
+
+Using the option of `--binary` can be used as a command instead of an alias.
 
 ## CLI
 
@@ -40,14 +61,16 @@ USAGE:
    aliases [global options] command [command options] [arguments...]
 
 VERSION:
-   0.0.0
+   dev
 
 COMMANDS:
-     generate, gen  Generate aliases
-     help, h        Shows a list of commands or help for one command
+     gen      Generate aliases
+     home     Get aliases home path
+     help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
    --config FILE, -c FILE  Load configuration from FILE
+   --home value            Home directory for aliases
    --help, -h              show help
    --version, -v           print the version
 ```

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -34,8 +34,9 @@ func GenAction(c *cli.Context) error {
 	cmds := aliases.GenerateCommands(*conf, *ctx)
 
 	// output aliases
+	export.WriteFiles(cmds, *conf, *ctx)
 	if c.Bool("binary") {
-		export.Script(cmds, *conf, *ctx)
+		export.Path(*conf, *ctx)
 	} else {
 		export.Aliases(cmds)
 	}

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -1,16 +1,21 @@
 package cmd
 
 import (
-	"fmt"
 	"github.com/k-kinzal/aliases/pkg"
+	"github.com/k-kinzal/aliases/pkg/export"
 	"github.com/urfave/cli"
 )
 
 func GenCommand() cli.Command {
 	return cli.Command {
-		Name:    "generate",
-		Aliases: []string{"gen"},
+		Name:    "gen",
 		Usage:   "Generate aliases",
+		Flags: []cli.Flag {
+			cli.BoolFlag{
+				Name: "binary",
+				Usage: "",
+			},
+		},
 		Action:  func(c *cli.Context) error {
 			return GenAction(c)
 		},
@@ -19,21 +24,20 @@ func GenCommand() cli.Command {
 
 func GenAction(c *cli.Context) error {
 	// context
-	context, err := aliases.NewContext(c.GlobalString("config"))
-	if err != nil {
-		return err
-	}
+	ctx := aliases.NewContext(c.GlobalString("home"), c.GlobalString("config"))
 	// configuration
-	conf, err := aliases.LoadConfFile(context.ConfPath)
+	conf, err := aliases.LoadConfFile(*ctx)
 	if err != nil {
 		return err
 	}
 	// generate commands
-	cmds := aliases.GenerateCommands(conf, context)
+	cmds := aliases.GenerateCommands(*conf, *ctx)
 
 	// output aliases
-	for _, cmd := range cmds {
-		fmt.Printf(cmd.ToString())
+	if c.Bool("binary") {
+		export.Script(cmds, *conf, *ctx)
+	} else {
+		export.Aliases(cmds)
 	}
 
 	return nil

--- a/cmd/home.go
+++ b/cmd/home.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/k-kinzal/aliases/pkg"
+	"github.com/urfave/cli"
+)
+
+func HomeCommand() cli.Command {
+	return cli.Command {
+		Name:    "home",
+		Usage:   "Get aliases home path",
+		Action:  func(c *cli.Context) error {
+			return HomeAction(c)
+		},
+	}
+}
+
+func HomeAction(c *cli.Context) error {
+	// context
+	ctx := aliases.NewContext("", "")
+
+	// output
+	fmt.Print(ctx.GetHomePath())
+
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -9,14 +9,8 @@ import (
 	"os"
 )
 
-var (
-	cmds []cli.Command
-)
-
 func init() {
 	logrus.SetOutput(os.Stdout)
-
-	cmds = append(cmds, cmd.GenCommand())
 }
 
 func main() {
@@ -31,8 +25,14 @@ func main() {
 			Name: "config, c",
 			Usage: "Load configuration from `FILE`",
 		},
+		cli.StringFlag{
+			Name: "home",
+			Usage: "Home directory for aliases",
+		},
 	}
-	app.Commands = cmds
+	app.Commands = []cli.Command{
+		cmd.GenCommand(),
+	}
 
 	err := app.Run(os.Args)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 	}
 	app.Commands = []cli.Command{
 		cmd.GenCommand(),
+		cmd.HomeCommand(),
 	}
 
 	err := app.Run(os.Args)

--- a/pkg/command.go
+++ b/pkg/command.go
@@ -359,6 +359,8 @@ func GenerateCommands(conf AliasesConf, ctx Context) []AliasCommand {
 			}
 		}
 
+		c.DockerConf.DockerOpts.Env["ALIASES_PWD"] = "${ALIASES_PWD:-$PWD}"
+
 		cmds = append(cmds, *NewAliasCommand(c, ctx))
 	}
 

--- a/pkg/command.go
+++ b/pkg/command.go
@@ -15,14 +15,14 @@ var (
 )
 
 type AliasCommand struct {
-	path string
-	filename string
-	cmd exec.Cmd
+	Path string
+	Filename string
+	Cmd exec.Cmd
 }
 
-func (c *AliasCommand) ToDockerRunString() string {
+func (c *AliasCommand)ToString() string {
 	args := make([]string, 0)
-	for i, arg := range c.cmd.Args {
+	for i, arg := range c.Cmd.Args {
 		if i == 0 {
 			continue
 		}
@@ -36,23 +36,10 @@ func (c *AliasCommand) ToDockerRunString() string {
 		}
 	}
 
-	return fmt.Sprintf("%s %s", c.cmd.Path, strings.Join(args, " "))
+	return fmt.Sprintf("%s %s", c.Cmd.Path, strings.Replace(strings.Join(args, " "), "'", "\\'", -1))
 }
 
-func (c *AliasCommand) ToString() string {
-	return fmt.Sprintf("alias %s='%s'\n", c.filename, strings.Replace(c.ToDockerRunString(), "'", "\\'", -1))
-}
-
-func GenerateCommands(conf *AliasesConf, ctx *Context) []*AliasCommand {
-	cmds := make([]*AliasCommand, 0)
-	for _, c := range conf.Aliases {
-		cmds = append(cmds, GenerateCommand(&c, ctx))
-	}
-
-	return cmds
-}
-
-func GenerateCommand(conf *AliasConf, ctx *Context) *AliasCommand {
+func NewAliasCommand(conf AliasConf, ctx Context) *AliasCommand {
 	cmd := exec.Command("docker", "run")
 
 	for _, v := range conf.DockerConf.DockerOpts.AddHost {
@@ -343,8 +330,17 @@ func GenerateCommand(conf *AliasConf, ctx *Context) *AliasCommand {
 	cmd.Stderr = os.Stderr
 
 	return &AliasCommand {
-		path: conf.Path,
-		filename: path.Base(conf.Path),
-		cmd: *cmd,
+		Path: conf.Path,
+		Filename: path.Base(conf.Path),
+		Cmd: *cmd,
 	}
+}
+
+func GenerateCommands(conf AliasesConf, ctx Context) []AliasCommand {
+	cmds := make([]AliasCommand, 0)
+	for _, c := range conf.Aliases {
+		cmds = append(cmds, *NewAliasCommand(c, ctx))
+	}
+
+	return cmds
 }

--- a/pkg/conf.go
+++ b/pkg/conf.go
@@ -136,13 +136,8 @@ func LoadConfFile(path string) (*AliasesConf, error) {
 
 	conf := new(AliasesConf)
 	conf.PathMap = make(map[string]*AliasConf)
-	for path, _ := range defs {
-		c := AliasConf{}
-		c.DockerConf.DockerOpts.Interactive = true
-		c.DockerConf.DockerOpts.Rm = true
-		c.DockerConf.DockerOpts.Network = ptrStr("host")
-
-		conf.PathMap[path] = &c
+	for path := range defs {
+		conf.PathMap[path] = &AliasConf{}
 	}
 
 	for path, def := range defs {

--- a/pkg/conf.go
+++ b/pkg/conf.go
@@ -137,7 +137,7 @@ func LoadConfFile(ctx Context) (*AliasesConf, error) {
 	}
 
 	conf := new(AliasesConf)
-	conf.Hash = uuid.NewMD5(uuid.New(), buf).String()
+	conf.Hash = uuid.NewMD5(uuid.UUID{}, buf).String()
 	conf.PathMap = make(map[string]*AliasConf)
 	for path := range defs {
 		conf.PathMap[path] = &AliasConf{}

--- a/pkg/conf.go
+++ b/pkg/conf.go
@@ -3,6 +3,7 @@ package aliases
 import (
 	"errors"
 	"fmt"
+	"github.com/google/uuid"
 	"io/ioutil"
 	"os"
 )
@@ -116,15 +117,16 @@ type AliasConf struct {
 
 type AliasesConf struct {
 	PathMap map[string]*AliasConf
+	Hash string
 	Aliases []AliasConf
 }
 
-func LoadConfFile(path string) (*AliasesConf, error) {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return nil, fmt.Errorf("configuration file is not exists `%s`", path)
+func LoadConfFile(ctx Context) (*AliasesConf, error) {
+	if _, err := os.Stat(ctx.GetConfPath()); os.IsNotExist(err) {
+		return nil, fmt.Errorf("configuration file is not exists `%s`", ctx.GetConfPath())
 	}
 
-	buf, err := ioutil.ReadFile(path)
+	buf, err := ioutil.ReadFile(ctx.GetConfPath())
 	if err != nil {
 		return nil, fmt.Errorf("configuration file cannot read `%q`", err)
 	}
@@ -135,6 +137,7 @@ func LoadConfFile(path string) (*AliasesConf, error) {
 	}
 
 	conf := new(AliasesConf)
+	conf.Hash = uuid.NewMD5(uuid.New(), buf).String()
 	conf.PathMap = make(map[string]*AliasConf)
 	for path := range defs {
 		conf.PathMap[path] = &AliasConf{}

--- a/pkg/context.go
+++ b/pkg/context.go
@@ -3,23 +3,43 @@ package aliases
 import (
 	"fmt"
 	"os"
+	"os/user"
 )
 
 type Context struct {
-	ConfPath string
+	homePath string
+	confPath string
 }
 
-func NewContext(path string) (*Context, error) {
-	if path == "" {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return nil, fmt.Errorf("cannot get PWD `%q`", err)
+func (ctx *Context)GetHomePath() string {
+	if ctx.homePath == "" {
+		ctx.homePath = os.Getenv("ALIASES_HOME")
+		if ctx.homePath == "" {
+			usr, _ := user.Current()
+			ctx.homePath = fmt.Sprintf("%s/.aliases", usr.HomeDir)
 		}
 
-		path = fmt.Sprintf("%s/aliases.yaml", cwd)
+		if _, err := os.Stat(ctx.homePath); os.IsNotExist(err) {
+			os.Mkdir(ctx.homePath, 0755)
+		}
 	}
-	context := new(Context)
-	context.ConfPath = path
 
-	return context, nil
+	return ctx.homePath
+}
+
+func (ctx *Context)GetBinaryPath(hash string) string {
+	return fmt.Sprintf("%s/%s", ctx.GetHomePath(), hash)
+}
+
+func (ctx *Context)GetConfPath() string {
+	if ctx.confPath == "" {
+		cwd, _ := os.Getwd()
+		ctx.confPath = fmt.Sprintf("%s/aliases.yaml", cwd)
+	}
+
+	return ctx.confPath
+}
+
+func NewContext(homePath string, confPath string) *Context {
+	return &Context{homePath, confPath}
 }

--- a/pkg/export/alias.go
+++ b/pkg/export/alias.go
@@ -1,0 +1,14 @@
+package export
+
+import (
+	"fmt"
+	"github.com/k-kinzal/aliases/pkg"
+)
+
+
+
+func Aliases(cmds []aliases.AliasCommand) {
+	for _, cmd := range cmds {
+		fmt.Printf(fmt.Sprintf("alias %s='%s'\n", cmd.Filename, cmd.ToString()))
+	}
+}

--- a/pkg/export/file.go
+++ b/pkg/export/file.go
@@ -11,16 +11,16 @@ var (
 	tmpl = `#!/bin/sh
 
 if [ -p /dev/stdin ]; then
-    cat - | %s $@
-	exit $?
+  cat - | %s $@
+  exit $?
 else
-    %s $@
-	exit $?
+  %s $@
+  exit $?
 fi
 `
 )
 
-func Script(cmds []aliases.AliasCommand, conf aliases.AliasesConf, ctx aliases.Context) {
+func WriteFiles(cmds []aliases.AliasCommand, conf aliases.AliasesConf, ctx aliases.Context) {
 	os.Remove(ctx.GetBinaryPath(conf.Hash))
 	os.Mkdir(ctx.GetBinaryPath(conf.Hash), 0755)
 
@@ -31,7 +31,4 @@ func Script(cmds []aliases.AliasCommand, conf aliases.AliasesConf, ctx aliases.C
 
 		ioutil.WriteFile(path, []byte(content), 0755)
 	}
-
-	fmt.Printf("export PATH=\"%s:$PATH\"", ctx.GetBinaryPath(conf.Hash))
-
 }

--- a/pkg/export/path.go
+++ b/pkg/export/path.go
@@ -1,0 +1,11 @@
+package export
+
+import (
+	"fmt"
+	"github.com/k-kinzal/aliases/pkg"
+)
+
+func Path(conf aliases.AliasesConf, ctx aliases.Context) {
+	fmt.Printf("export PATH=\"%s:$PATH\"", ctx.GetBinaryPath(conf.Hash))
+
+}

--- a/pkg/export/script.go
+++ b/pkg/export/script.go
@@ -1,0 +1,37 @@
+package export
+
+import (
+	"fmt"
+	"github.com/k-kinzal/aliases/pkg"
+	"io/ioutil"
+	"os"
+)
+
+var (
+	tmpl = `#!/bin/sh
+
+if [ -p /dev/stdin ]; then
+    cat - | %s $@
+	exit $?
+else
+    %s $@
+	exit $?
+fi
+`
+)
+
+func Script(cmds []aliases.AliasCommand, conf aliases.AliasesConf, ctx aliases.Context) {
+	os.Remove(ctx.GetBinaryPath(conf.Hash))
+	os.Mkdir(ctx.GetBinaryPath(conf.Hash), 0755)
+
+	for _, cmd := range cmds {
+		str := cmd.ToString()
+		path := fmt.Sprintf("%s/%s", ctx.GetBinaryPath(conf.Hash), cmd.Filename)
+		content := fmt.Sprintf(tmpl, str, str)
+
+		ioutil.WriteFile(path, []byte(content), 0755)
+	}
+
+	fmt.Printf("export PATH=\"%s:$PATH\"", ctx.GetBinaryPath(conf.Hash))
+
+}

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -5,10 +5,6 @@ import (
 	"strings"
 )
 
-func ptrStr(s string) *string {
-	return &s
-}
-
 func expandColonDelimitedStringWithEnv(s string) string {
 	arr := strings.Split(s, ":")
 	if len(arr) > 0 {

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -5,10 +5,18 @@ import (
 	"strings"
 )
 
+func expandEnv(str string) string {
+	str = strings.Replace(str, "$PWD", "{{ ALIASES_PWD }}", -1)
+	str = os.ExpandEnv(str)
+	str = strings.Replace(str,"{{ ALIASES_PWD }}", "${ALIASES_PWD:-$PWD}", -1)
+
+	return str
+}
+
 func expandColonDelimitedStringWithEnv(s string) string {
 	arr := strings.Split(s, ":")
 	if len(arr) > 0 {
-		arr[0] = os.ExpandEnv(arr[0])
+		arr[0] = expandEnv(arr[0])
 	}
 	return strings.Join(arr, ":")
 }
@@ -25,7 +33,7 @@ func expandColonDelimitedStringListWithEnv(arr []string) []string {
 func expandStringKeyMapWithEnv(m map[string]string) map[string]string {
 	rets := make(map[string]string, 0)
 	for k, v := range m {
-		rets[os.ExpandEnv(k)] = v
+		rets[expandEnv(k)] = v
 	}
 
 	return rets

--- a/pkg/yaml.go
+++ b/pkg/yaml.go
@@ -16,7 +16,7 @@ type YamlDefinition struct {
 	Args    []string `yaml:"args"`
 	// docker run options
 	AddHost             []string          `yaml:"add-host"`
-	Attach              []string          `yaml:"attach" oneof:"STDIN STDOUT STDERR"`
+	Attach              []string          `yaml:"attach" validate:"dive,oneof=STDIN STDOUT STDERR"`
 	BlkioWeight         *uint16           `yaml:"blkio-weight"`
 	BlkioWeightDevice   []string          `yaml:"blkio-weight-device"`
 	CapAdd              []string          `yaml:"cap-add"`
@@ -117,7 +117,7 @@ func UnmarshalConfFile(buf []byte) (map[string]YamlDefinition, error) {
 		if err := defaults.Set(&def); err != nil {
 			return nil, err
 		}
-		if err := validator.New().Struct(&def); err != nil {
+		if err := validator.New().Struct(def); err != nil {
 			return nil, err
 		}
 		defs[idx] = def

--- a/pkg/yaml.go
+++ b/pkg/yaml.go
@@ -1,6 +1,7 @@
 package aliases
 
 import (
+	"github.com/creasty/defaults"
 	"gopkg.in/go-playground/validator.v9"
 	"gopkg.in/yaml.v2"
 )
@@ -15,7 +16,7 @@ type YamlDefinition struct {
 	Args    []string `yaml:"args"`
 	// docker run options
 	AddHost             []string          `yaml:"add-host"`
-	Attach              []string          `yaml:"attach"`
+	Attach              []string          `yaml:"attach" oneof:"STDIN STDOUT STDERR"`
 	BlkioWeight         *uint16           `yaml:"blkio-weight"`
 	BlkioWeightDevice   []string          `yaml:"blkio-weight-device"`
 	CapAdd              []string          `yaml:"cap-add"`
@@ -54,7 +55,7 @@ type YamlDefinition struct {
 	HealthTimeout       *int              `yaml:"health-timeout"`
 	Hostname            *string           `yaml:"hostname"`
 	Init                bool              `yaml:"init"`
-	Interactive         bool              `yaml:"interactive"`
+	Interactive         bool              `yaml:"interactive" default:"true"`
 	Ip                  *string           `yaml:"ip"`
 	Ip6                 *string           `yaml:"ip6"`
 	Ipc                 *string           `yaml:"ipc"`
@@ -73,7 +74,7 @@ type YamlDefinition struct {
 	MemorySwappiness    *int              `yaml:"memory-swappiness"`
 	Mount               map[string]string `yaml:"mount"`
 	Name                *string           `yaml:"name"`
-	Network             *string           `yaml:"network"`
+	Network             *string           `yaml:"network" default:"host"`
 	NetworkAlias        []string          `yaml:"network-alias"`
 	NoHealthcheck       bool              `yaml:"no-healthcheck"`
 	OomKillDisable      bool              `yaml:"oom-kill-disable"`
@@ -86,7 +87,7 @@ type YamlDefinition struct {
 	PublishAll          bool              `yaml:"publish-all"`
 	ReadOnly            bool              `yaml:"read-only"`
 	Restart             *string           `yaml:"restart"`
-	Rm                  bool              `yaml:"rm"`
+	Rm                  bool              `yaml:"rm" default:"true"`
 	Runtime             *string           `yaml:"runtime"`
 	SecurityOpt         map[string]string `yaml:"security-opt"`
 	ShmSize             *int              `yaml:"shm-size"`
@@ -112,10 +113,14 @@ func UnmarshalConfFile(buf []byte) (map[string]YamlDefinition, error) {
 	if err := yaml.Unmarshal(buf, &defs); err != nil {
 		return nil, err
 	}
-	for _, def := range defs {
-		if err := validator.New().Struct(def); err != nil {
+	for idx, def := range defs {
+		if err := defaults.Set(&def); err != nil {
 			return nil, err
 		}
+		if err := validator.New().Struct(&def); err != nil {
+			return nil, err
+		}
+		defs[idx] = def
 	}
 
 	return defs, nil


### PR DESCRIPTION
We have solved the dependency of the command which depends on another command.

**aliases.yaml**
```
commandA:
  ...
commandB:
  dependencies:
  - commandA
```

**docker run command**
```
docker run --env "ALIASES_PWD=${ALIASES_PWD:-$PWD}" --interactive --network host --privileged --rm  --volume "/usr/local/bin/docker:/usr/local/bin/docker" --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "~/.aliases/64ee486a-9a1e-337d-b828-75e91a40c624/commandA:/usr/local/bin/commandA" "commandB:${COMMAND_B_VERSION:...}"
```

Along with that, the option of `--binary` to generate a command and to make PATH has been added.