### PR TITLE
fix(doc): `eval $(aliases gen)` requires double-quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ $ go get github.com/k-kinzal/aliases
 ```
 
 ```
-$ eval $(aliases gen)
+$ eval "$(aliases gen)"
 ```
 
 or 
 
 ```
-$ eval $(aliases gen --binary)
+$ eval "$(aliases gen --binary)"
 ```
 
 


### PR DESCRIPTION
when there are two or more aliases to be generated. Otherwise invoking `eval $(aliases gen)` against the default aliases.yaml produces an error like this on my box:

```console
$ eval $(aliases gen)
-bash: alias: alias: not found
```