### PR TITLE
fix: default DOCKER_HOST

### DIFF
--- a/pkg/command.go
+++ b/pkg/command.go
@@ -343,7 +343,7 @@ func GenerateCommands(conf AliasesConf, ctx Context) []AliasCommand {
 			c.DockerConf.DockerOpts.Privileged = true
 			c.DockerConf.DockerOpts.Volume = append(c.DockerConf.DockerOpts.Volume, fmt.Sprintf("%s:/usr/local/bin/docker", exec.Command("docker").Path))
 			host := os.Getenv("DOCKER_HOST")
-			if host != "" {
+			if host == "" {
 				host = "unix:///var/run/docker.sock"
 			}
 			if strings.HasPrefix(host, "unix://") {


### PR DESCRIPTION
Fixed an issue that could not be initialized when DOCKER_HOST was empty.