### PR TITLE
fix: docker run $@ -> "$@"

### DIFF
--- a/pkg/export/file.go
+++ b/pkg/export/file.go
@@ -11,10 +11,10 @@ var (
 	tmpl = `#!/bin/sh
 
 if [ -p /dev/stdin ]; then
-  cat - | %s $@
+  cat - | %s "$@"
   exit $?
 else
-  %s $@
+  %s "$@"
   exit $?
 fi
 `


### PR DESCRIPTION
In `$@`, it is separated by IFS.

```
$ echo "{}" | jq -r '. | .'
jq: error: Could not open file |: No such file or directory
```

So I modified `"$@"` to use it.