### PR TITLE
refactor cli interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ $ eval "$(aliases gen)"
 or 
 
 ```
-$ eval "$(aliases gen --binary)"
+$ eval "$(aliases gen --export)"
 ```
 
 
-Using the option of `--binary` can be used as a command instead of an alias.
+Using the option of `--export` can be used as a command instead of an alias.
 
 ## CLI
 

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -10,19 +10,19 @@ import (
 type GenContext struct {
 	*context.Context
 
-	binary bool
+	export bool
 }
 
 func NewGenContext(c *cli.Context) *GenContext {
 	ctx := context.NewContext(
 		c.GlobalString("home"),
 		c.GlobalString("config"),
-		c.String("binary-path"),
+		c.String("export-path"),
 	)
 
 	return &GenContext{
 		Context: ctx,
-		binary: c.Bool("binary"),
+		export: c.Bool("export"),
 	}
 }
 
@@ -32,11 +32,11 @@ func GenCommand() cli.Command {
 		Usage:   "Generate aliases",
 		Flags: []cli.Flag {
 			cli.BoolFlag{
-				Name: "binary",
+				Name: "export",
 				Usage: "If you pass true, you will return export instead of aliase",
 			},
 			cli.StringFlag{
-				Name: "binary-path",
+				Name: "export-path",
 				Usage: "The directory to put binaries",
 			},
 		},
@@ -57,7 +57,7 @@ func GenAction(c *cli.Context) error {
 	}
 
 	// output aliases
-	if ctx.binary {
+	if ctx.export {
 		export.Path(ctx.Context, conf)
 	} else {
 		export.Aliases(ctx.Context, conf)

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -51,16 +51,16 @@ func GenAction(c *cli.Context) error {
 	ctx := NewGenContext(c)
 
 	// configuration
-	conf, err := conf.LoadConfFile(ctx.Context)
+	cf, err := conf.LoadConfFile(ctx.Context)
 	if err != nil {
 		return err
 	}
 
 	// output aliases
 	if ctx.export {
-		export.Path(ctx.Context, conf)
+		export.Path(ctx.Context, cf)
 	} else {
-		export.Aliases(ctx.Context, conf)
+		export.Aliases(ctx.Context, cf)
 	}
 
 	return nil

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -33,11 +33,11 @@ func GenCommand() cli.Command {
 		Flags: []cli.Flag {
 			cli.BoolFlag{
 				Name: "binary",
-				Usage: "",
+				Usage: "If you pass true, you will return export instead of aliase",
 			},
 			cli.StringFlag{
 				Name: "binary-path",
-				Usage: "the directory to put binaries. works only when --binary is specified",
+				Usage: "The directory to put binaries",
 			},
 		},
 		Action:  func(c *cli.Context) error {

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -204,7 +204,7 @@ func LoadConfFile(ctx *context.Context) (*AliasesConf, error) {
 			c.DockerRunOpts.Env["ALIASES_PWD"] = "${ALIASES_PWD:-$PWD}"
 
 			for _, dep := range c.Dependencies {
-				from := fmt.Sprintf("%s/%s", ctx.GetBinaryPath(), path.Base(dep.Path))
+				from := fmt.Sprintf("%s/%s", ctx.GetExportPath(), path.Base(dep.Path))
 				volume := fmt.Sprintf("%s:/usr/local/bin/%s", from, path.Base(dep.Path))
 				c.DockerRunOpts.Volume = append(c.DockerRunOpts.Volume, volume)
 			}

--- a/pkg/conf/conf_test.go
+++ b/pkg/conf/conf_test.go
@@ -100,7 +100,7 @@ func TestUnmarshalConfFile_ShouldBeSetDependenciesWithUnixSock(t *testing.T) {
 	if command.DockerRunOpts.Volume[1] != "/var/run/docker.sock:/var/run/docker.sock" {
 		t.Errorf("expected `/var/run/docker.sock:/var/run/docker.sock`, but in actual `%s` has been set in dockerrunopts.volume[1]", command.DockerRunOpts.Volume[1])
 	}
-	mauntPath := fmt.Sprintf("%s/%s", ctx.GetBinaryPath(), path.Base(command.Dependencies[0].Path))
+	mauntPath := fmt.Sprintf("%s/%s", ctx.GetExportPath(), path.Base(command.Dependencies[0].Path))
 	volume := fmt.Sprintf("%s:%s", mauntPath, command.Dependencies[0].Path)
 	if command.DockerRunOpts.Volume[2] != volume {
 		t.Errorf("expected `%s`, but in actual `%s` has been set in dockerrunopts.volume[2]", volume, command.DockerRunOpts.Volume[1])
@@ -143,7 +143,7 @@ func TestUnmarshalConfFile_ShouldBeSetDependenciesWithHost(t *testing.T) {
 	if command.DockerRunOpts.Volume[0] != "/usr/local/bin/docker:/usr/local/bin/docker" {
 		t.Errorf("expected `/usr/local/bin/docker:/usr/local/bin/docker`, but in actual `%s` has been set in dockerrunopts.volume[0]", command.DockerRunOpts.Volume[0])
 	}
-	mauntPath := fmt.Sprintf("%s/%s", ctx.GetBinaryPath(), path.Base(command.Dependencies[0].Path))
+	mauntPath := fmt.Sprintf("%s/%s", ctx.GetExportPath(), path.Base(command.Dependencies[0].Path))
 	volume := fmt.Sprintf("%s:%s", mauntPath, command.Dependencies[0].Path)
 	if command.DockerRunOpts.Volume[1] != volume {
 		t.Errorf("expected `%s`, but in actual `%s` has been set in dockerrunopts.volume[1]", volume, command.DockerRunOpts.Volume[1])

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -10,17 +10,17 @@ import (
 type Context struct {
 	homePath string
 	confPath string
-	binaryPath string
+	exportPath string
 }
 
 func NewContext(
 		homePath string,
 		confPath string,
-		binaryPath string) *Context {
+		exportPath string) *Context {
 	return &Context{
 		homePath: homePath,
 		confPath: confPath,
-		binaryPath: binaryPath,
+		exportPath: exportPath,
 	}
 }
 
@@ -58,13 +58,13 @@ func (ctx *Context)GetConfPath() string {
 }
 
 
-func (ctx *Context)GetBinaryPath() string {
-	if ctx.binaryPath != "" {
-		return ctx.binaryPath
+func (ctx *Context)GetExportPath() string {
+	if ctx.exportPath != "" {
+		return ctx.exportPath
 	}
 
 	hash := uuid.NewMD5(uuid.UUID{}, []byte(ctx.GetHomePath())).String()
-	ctx.binaryPath = fmt.Sprintf("%s/%s", ctx.GetHomePath(), hash)
+	ctx.exportPath = fmt.Sprintf("%s/%s", ctx.GetHomePath(), hash)
 
-	return ctx.binaryPath
+	return ctx.exportPath
 }

--- a/pkg/export/alias.go
+++ b/pkg/export/alias.go
@@ -12,7 +12,7 @@ import (
 
 
 func Aliases(ctx *context.Context, conf *conf.AliasesConf) {
-	dir := ctx.GetBinaryPath()
+	dir := ctx.GetExportPath()
 	os.Remove(dir)
 	os.Mkdir(dir, 0755)
 

--- a/pkg/export/path.go
+++ b/pkg/export/path.go
@@ -12,8 +12,8 @@ func Path(ctx *context.Context, conf *conf.AliasesConf) {
 	os.Remove(dir)
 	os.Mkdir(dir, 0755)
 
-	for _, conf := range conf.Commands {
-		writeFiles(&conf, dir)
+	for _, cf := range conf.Commands {
+		writeFiles(&cf, dir)
 	}
 
 	fmt.Printf("export PATH=\"%s:$PATH\"", dir)

--- a/pkg/export/path.go
+++ b/pkg/export/path.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Path(ctx *context.Context, conf *conf.AliasesConf) {
-	dir := ctx.GetBinaryPath()
+	dir := ctx.GetExportPath()
 	os.Remove(dir)
 	os.Mkdir(dir, 0755)
 


### PR DESCRIPTION
Refactoring `binary` to `export` because it is not intuitive.