### PR TITLE
fix: duplicate docker command

### DIFF
--- a/pkg/export/alias.go
+++ b/pkg/export/alias.go
@@ -20,6 +20,6 @@ func Aliases(ctx *context.Context, conf *conf.AliasesConf) {
 			writeFiles(dep, dir)
 		}
 		cmd := docker.NewRunCmd(&c.DockerRunOpts)
-		fmt.Printf(fmt.Sprintf("alias %s='%s %s'\n", path.Base(cmd.Path), cmd.Path, strings.Join(cmd.Args, " ")))
+		fmt.Printf(fmt.Sprintf("alias %s='%s %s'\n", path.Base(cmd.Path), cmd.Path, strings.Join(cmd.Args[1:], " ")))
 	}
 }

--- a/pkg/export/file.go
+++ b/pkg/export/file.go
@@ -24,7 +24,7 @@ fi
 
 func writeFiles(conf *conf.CommandConf, dir string) {
 	cmd := docker.NewRunCmd(&conf.DockerRunOpts)
-	cmdStr := fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+	cmdStr := fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args[1:], " "))
 	writePath := fmt.Sprintf("%s/%s", dir, path.Base(conf.Path))
 	content := fmt.Sprintf(tmpl, cmdStr, cmdStr)
 	ioutil.WriteFile(writePath, []byte(content), 0755)


### PR DESCRIPTION
Generated `docker run` command is different from the expected result.

**expect**
```
/usr/local/bin/docker run --interactive --network "host" --rm --volume "/Users/k-kinzal/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --workdir "/kube" chatwork/kubectl:${KUBECTL_VERSION:-"1.11.2"} "$@"
```

**actual**
```
/usr/local/bin/docker docker run --interactive --network "host" --rm --volume "/Users/k-kinzal/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --workdir "/kube" chatwork/kubectl:${KUBECTL_VERSION:-"1.11.2"} "$@"
```