### PR TITLE
fix: behavior of `aliases run` command argument

### DIFF
--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -120,28 +120,3 @@ func (h *helper) stringMap(names ...string) map[string]string {
 
 	return val
 }
-
-func (h *helper) args() []string {
-	args := make([]string, 0, h.Context.NArg()-1)
-	for _, arg := range h.Context.Args()[1:] {
-		if arg == "--" {
-			continue
-		}
-		args = append(args, arg)
-	}
-	return args
-}
-
-func (h *helper) firstArg() *string {
-	args := h.Context.Args()
-	if len(args) == 0 {
-		return nil
-	}
-	if args[0] == "--" {
-		if len(args) == 1 {
-			return nil
-		}
-		return &args[1]
-	}
-	return &args[0]
-}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -284,7 +284,7 @@ func RunAction(c *cli.Context) error {
 	}
 
 	index := c.Args()[0]
-	if err := ledger.Entry(index, *ctx.GetCommandShema()); err != nil {
+	if err := ledger.Merge(index, *ctx.GetCommandShema()); err != nil {
 		return err
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -18,12 +18,25 @@ type runContext struct {
 
 func (ctx *runContext) GetCommandShema() *aliases.Schema {
 	flags := ctx.flags
+	arguments := flags.Args()
 
-	index := flags.firstArg()
-	args := flags.args()
+	if len(arguments) == 0 {
+		return nil
+	}
+	index := arguments[0]
+
+	var command *string
+	if len(arguments) > 2 {
+		command = &arguments[1]
+	}
+	var args []string
+	if len(arguments) > 3 {
+		args = arguments[2:]
+	}
+
 	schema := aliases.Schema{
-		*index,
-		path.Base(*index),
+		index,
+		path.Base(index),
 		nil,
 		flags.bool("detach", "d"),
 		flags.bool("sig-proxy"),
@@ -118,9 +131,9 @@ func (ctx *runContext) GetCommandShema() *aliases.Schema {
 		flags.string("runtime"),
 		flags.bool("init"),
 		"",
-		args[1:],
+		args,
 		"",
-		&args[0],
+		command,
 	}
 
 	return &schema

--- a/test/integration/dependencies/test.sh
+++ b/test/integration/dependencies/test.sh
@@ -15,4 +15,4 @@ cat ${TEMP_DIR}/kubectl | ${MASK} | ${DIFF} ${TEST_DIR}/kubectl -
 cat ${TEMP_DIR}/alpine | ${MASK} |${DIFF} ${TEST_DIR}/alpine -
 
 ${TEMP_DIR}/alpine /bin/sh -c "kubectl version --client" | ${MASK} | ${DIFF} ${TEST_DIR}/stdout -
-${ALIASES} run /usr/local/bin/alpine /bin/sh -c "ls -la /usr/local/bin"
+${ALIASES} run /usr/local/bin/alpine /bin/sh -c "kubectl version --client" | ${MASK} | ${DIFF} ${TEST_DIR}/stdout -


### PR DESCRIPTION
I fixed a problem with argument of `aliases run` command.

```
$ aliases -v run /usr/local/bin/bash     
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
github.com/k-kinzal/aliases/cmd.(*runContext).GetCommandShema(0xc0001f9e60, 0x25)
	/Users/k-kinzal/Projects/go/src/github.com/k-kinzal/aliases/cmd/run.go:121 +0x2e6b
github.com/k-kinzal/aliases/cmd.RunAction(0xc0001ea420, 0xc000173000, 0xc0001ea420)
	/Users/k-kinzal/Projects/go/src/github.com/k-kinzal/aliases/cmd/run.go:274 +0x143
github.com/k-kinzal/aliases/vendor/github.com/urfave/cli.HandleAction(0x1288740, 0x12eadb0, 0xc0001ea420, 0x0, 0xc0001f45a0)
	/Users/k-kinzal/Projects/go/src/github.com/k-kinzal/aliases/vendor/github.com/urfave/cli/app.go:501 +0xc8
github.com/k-kinzal/aliases/vendor/github.com/urfave/cli.Command.Run(0x12da3a7, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x12de243, 0x13, 0x12e9170, ...)
	/Users/k-kinzal/Projects/go/src/github.com/k-kinzal/aliases/vendor/github.com/urfave/cli/command.go:165 +0x459
github.com/k-kinzal/aliases/vendor/github.com/urfave/cli.(*App).Run(0xc0001e21c0, 0xc0000940c0, 0x4, 0x4, 0x0, 0x0)
	/Users/k-kinzal/Projects/go/src/github.com/k-kinzal/aliases/vendor/github.com/urfave/cli/app.go:259 +0x6bb
main.main()
	/Users/k-kinzal/Projects/go/src/github.com/k-kinzal/aliases/main.go:74 +0x84e
```

```
$ aliases -v run --   
panic: runtime error: makeslice: cap out of range

goroutine 1 [running]:
github.com/k-kinzal/aliases/cmd.(*helper).args(0xc0001f7f90, 0xc0001f7f80, 0x0, 0x0)
	/Users/k-kinzal/Projects/go/src/github.com/k-kinzal/aliases/cmd/helper.go:125 +0x58
github.com/k-kinzal/aliases/cmd.RunAction(0xc0001ca6e0, 0xc000151000, 0xc0001ca6e0)
	/Users/k-kinzal/Projects/go/src/github.com/k-kinzal/aliases/cmd/run.go:270 +0x85
github.com/k-kinzal/aliases/vendor/github.com/urfave/cli.HandleAction(0x1288900, 0x12eaf78, 0xc0001ca6e0, 0x0, 0xc0001f4840)
	/Users/k-kinzal/Projects/go/src/github.com/k-kinzal/aliases/vendor/github.com/urfave/cli/app.go:501 +0xc8
github.com/k-kinzal/aliases/vendor/github.com/urfave/cli.Command.Run(0x12da567, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x12de409, 0x13, 0x12e9336, ...)
	/Users/k-kinzal/Projects/go/src/github.com/k-kinzal/aliases/vendor/github.com/urfave/cli/command.go:165 +0x459
github.com/k-kinzal/aliases/vendor/github.com/urfave/cli.(*App).Run(0xc0001c21c0, 0xc000010180, 0x4, 0x4, 0x0, 0x0)
	/Users/k-kinzal/Projects/go/src/github.com/k-kinzal/aliases/vendor/github.com/urfave/cli/app.go:259 +0x6bb
main.main()
	/Users/k-kinzal/Projects/go/src/github.com/k-kinzal/aliases/main.go:74 +0x84e
```

```
$ aliases -v run abc                                                                     
runtime error: abc: schema is not exists
```