### PR TITLE
fix: command and arguments were not passed in aliases run

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -33,11 +33,11 @@ func (ctx *runContext) GetCommandShema() *aliases.Schema {
 	index := arguments[0]
 
 	var command *string
-	if len(arguments) > 2 {
+	if len(arguments) > 1 {
 		command = &arguments[1]
 	}
 	var args []string
-	if len(arguments) > 3 {
+	if len(arguments) > 2 {
 		args = arguments[2:]
 	}
 


### PR DESCRIPTION
```
$ aliases --verbose run -it --entrypoint '' xxx /bin/sh
docker run --entrypoint "" --interactive --network "host" --rm --tty --volume "/tmp:/tmp" xxx
docker: Error response from daemon: No command specified.
See 'docker run --help'.
```

I fixed this because it was not working.