### PR TITLE
Change command to alias of entrypoint

### DIFF
--- a/pkg/aliases/script/script.go
+++ b/pkg/aliases/script/script.go
@@ -121,11 +121,7 @@ func NewScript(client *docker.Client, opt config.Option) *Script {
 	// image
 	image := fmt.Sprintf("%s:${%s_VERSION:-\"%s\"}", opt.Image, strings.ToUpper(opt.FileName), opt.Tag)
 	// args
-	args := make([]string, 0)
-	if opt.Command != nil {
-		args = append(args, *opt.Command)
-	}
-	args = append(args, opt.Args...)
+	args := opt.Args
 	// options
 	o := docker.RunOption{}
 	o.AddHost = ExpandColonDelimitedStringListWithEnv(opt.AddHost)
@@ -157,7 +153,11 @@ func NewScript(client *docker.Client, opt config.Option) *Script {
 	o.DeviceWriteIOPS = ExpandColonDelimitedStringListWithEnv(opt.DeviceWriteIOPS)
 	o.DisableContentTrust = opt.DisableContentTrust
 	o.Domainname = opt.Domainname
-	o.Entrypoint = opt.Entrypoint
+	if opt.Command != nil {
+		o.Entrypoint = opt.Command
+	} else {
+		o.Entrypoint = opt.Entrypoint
+	}
 	o.Env = ExpandStringKeyMapWithEnv(opt.Env)
 	o.EnvFile = opt.EnvFile
 	o.Expose = opt.Expose

--- a/test/integration/simple/alias
+++ b/test/integration/simple/alias
@@ -1,1 +1,1 @@
-alias alpine='[TEMP_DIR]/alpine'
+alias sh='[TEMP_DIR]/sh'

--- a/test/integration/simple/aliases.yaml
+++ b/test/integration/simple/aliases.yaml
@@ -1,3 +1,5 @@
-/usr/local/bin/alpine:
+/usr/local/bin/sh:
   image: alpine
   tag: 3.8
+  command: sh
+  args: [-c]

--- a/test/integration/simple/alpine
+++ b/test/integration/simple/alpine
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-if [ -p /dev/stdin ]; then
-  cat - | docker run --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") alpine:${ALPINE_VERSION:-"3.8"} "$@"
-  exit $?
-else
-  echo "" >/dev/null | docker run --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") alpine:${ALPINE_VERSION:-"3.8"} "$@"
-  exit $?
-fi

--- a/test/integration/simple/sh
+++ b/test/integration/simple/sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -p /dev/stdin ]; then
+  cat - | docker run --entrypoint "sh" --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") alpine:${SH_VERSION:-"3.8"} -c "$@"
+  exit $?
+else
+  echo "" >/dev/null | docker run --entrypoint "sh" --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") alpine:${SH_VERSION:-"3.8"} -c "$@"
+  exit $?
+fi

--- a/test/integration/simple/test.sh
+++ b/test/integration/simple/test.sh
@@ -11,7 +11,7 @@ MASK="sed -e s|${HOME}|[HOME]|g -e s|${TEMP_DIR}|[TEMP_DIR]|g"
 
 ${ALIASES} gen --export-path "${TEMP_DIR}" | ${MASK} | sort | ${DIFF} ${TEST_DIR}/alias -
 ${ALIASES} gen --export --export-path "${TEMP_DIR}" | ${MASK} | ${DIFF} ${TEST_DIR}/export -
-cat ${TEMP_DIR}/alpine | ${MASK} | ${DIFF} ${TEST_DIR}/alpine -
+cat ${TEMP_DIR}/sh | ${MASK} | ${DIFF} ${TEST_DIR}/sh -
 
-${TEMP_DIR}/alpine /bin/sh -c "echo foo" | ${DIFF} ${TEST_DIR}/stdout -
-${ALIASES} run /usr/local/bin/alpine /bin/sh -c "echo foo" | ${DIFF} ${TEST_DIR}/stdout -
+${TEMP_DIR}/sh "echo foo" | ${DIFF} ${TEST_DIR}/stdout -
+${ALIASES} run /usr/local/bin/sh -c "echo foo" | ${DIFF} ${TEST_DIR}/stdout -


### PR DESCRIPTION
The command is assumed to be used like this:

```yaml
/usr/local/bin/sh:
  image: alpine
  tag: 3.8
  command: sh
  args: [-c]
```

However, docker image set with entrypoint does not work as expected.
The command should be an entrypoint, not the first argument.