### PR TITLE
refactor execute expansion of boolean parameter shortened

### DIFF
--- a/pkg/aliases/script/script_test.go
+++ b/pkg/aliases/script/script_test.go
@@ -166,7 +166,7 @@ func ExampleScript_StringWithOverride() {
 
 	cmd := script.NewScript(client, *opt)
 	fmt.Println(cmd.StringWithOverride([]string{"-c", "echo 1"}, docker.RunOption{Env: map[string]string{"FOO": "1"}}))
-	// Output: docker run --entrypoint "sh" --env FOO="1" --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") alpine:${COMMAND1_VERSION:-"latest"} -c "echo 1"
+	// Output: docker run --entrypoint "sh" --env FOO="1" --interactive --network "host" --rm $(tty >/dev/null && echo "--tty") alpine:${COMMAND1_VERSION:-"latest"} -c "echo 1"
 }
 
 func ExampleScript_String() {
@@ -205,7 +205,7 @@ func ExampleScript_String() {
 
 	cmd := script.NewScript(client, *opt)
 	fmt.Println(cmd.String())
-	// Output: docker run --entrypoint "sh" --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") alpine:${COMMAND1_VERSION:-"latest"} -c
+	// Output: docker run --entrypoint "sh" --interactive --network "host" --rm $(tty >/dev/null && echo "--tty") alpine:${COMMAND1_VERSION:-"latest"} -c
 }
 
 func ExampleScript_Shell() {
@@ -250,10 +250,10 @@ func ExampleScript_Shell() {
 	fmt.Println(shell.String())
 	// Output:
 	// if [ -p /dev/stdin ]; then
-	//   cat - | docker run --entrypoint "sh" --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") alpine:${COMMAND1_VERSION:-"latest"} -c "$@"
+	//   cat - | docker run --entrypoint "sh" --interactive --network "host" --rm $(tty >/dev/null && echo "--tty") alpine:${COMMAND1_VERSION:-"latest"} -c "$@"
 	//   exit $?
 	// else
-	//   echo "" >/dev/null | docker run --entrypoint "sh" --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") alpine:${COMMAND1_VERSION:-"latest"} -c "$@"
+	//   echo "" >/dev/null | docker run --entrypoint "sh" --interactive --network "host" --rm $(tty >/dev/null && echo "--tty") alpine:${COMMAND1_VERSION:-"latest"} -c "$@"
 	//   exit $?
 	// fi
 }

--- a/pkg/aliases/yaml/config.go
+++ b/pkg/aliases/yaml/config.go
@@ -105,7 +105,7 @@ type OptionSpec struct {
 	StopTimeout         *string           `yaml:"stopTimeout" validate:"omitempty,int|shell"`
 	StorageOpt          map[string]string `yaml:"storageOpt"`
 	Sysctl              map[string]string `yaml:"sysctl"`
-	TTY                 *string           `yaml:"tty" validate:"omitempty,bool|shell" default:"$(if tty >/dev/null; then echo true; else echo false; fi)"`
+	TTY                 *string           `yaml:"tty" validate:"omitempty,bool|shell" default:"tty >/dev/null"`
 	Tmpfs               []string          `yaml:"tmpfs"`
 	UTS                 *string           `yaml:"uts"`
 	Ulimit              map[string]string `yaml:"ulimit"`

--- a/pkg/docker/run.go
+++ b/pkg/docker/run.go
@@ -160,7 +160,7 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		if *v == "true" {
 			cmd.Args = append(cmd.Args, "--detach")
 		} else {
-			cmd.Args = append(cmd.Args, fmt.Sprintf("$(test %s = \"true\" && echo \"--detach\")", strconv.Quote(*v)))
+			cmd.Args = append(cmd.Args, fmt.Sprintf("$(%s && echo \"--detach\")", *v))
 		}
 	}
 	if v := option.DetachKeys; v != nil {
@@ -188,7 +188,7 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		if *v == "true" {
 			cmd.Args = append(cmd.Args, "--disable-content-trust")
 		} else {
-			cmd.Args = append(cmd.Args, fmt.Sprintf("$(test %s = \"true\" && echo \"--disable-content-trust\")", strconv.Quote(*v)))
+			cmd.Args = append(cmd.Args, fmt.Sprintf("$(%s && echo \"--disable-content-trust\")", *v))
 		}
 	}
 	for _, v := range option.DNS {
@@ -237,14 +237,14 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		if *v == "true" {
 			cmd.Args = append(cmd.Args, "--init")
 		} else {
-			cmd.Args = append(cmd.Args, fmt.Sprintf("$(test %s = \"true\" && echo \"--init\")", strconv.Quote(*v)))
+			cmd.Args = append(cmd.Args, fmt.Sprintf("$(%s && echo \"--init\")", *v))
 		}
 	}
 	if v := option.Interactive; v != nil && *v != "false" {
 		if *v == "true" {
 			cmd.Args = append(cmd.Args, "--interactive")
 		} else {
-			cmd.Args = append(cmd.Args, fmt.Sprintf("$(test %s = \"true\" && echo \"--interactive\")", strconv.Quote(*v)))
+			cmd.Args = append(cmd.Args, fmt.Sprintf("$(%s && echo \"--interactive\")", *v))
 		}
 	}
 	if v := option.IP; v != nil {
@@ -311,14 +311,14 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		if *v == "true" {
 			cmd.Args = append(cmd.Args, "--no-healthcheck")
 		} else {
-			cmd.Args = append(cmd.Args, fmt.Sprintf("$(test %s = \"true\" && echo \"--no-healthcheck\")", strconv.Quote(*v)))
+			cmd.Args = append(cmd.Args, fmt.Sprintf("$(%s && echo \"--no-healthcheck\")", *v))
 		}
 	}
 	if v := option.OOMKillDisable; v != nil && *v != "false" {
 		if *v == "true" {
 			cmd.Args = append(cmd.Args, "--oom-kill-disable")
 		} else {
-			cmd.Args = append(cmd.Args, fmt.Sprintf("$(test %s = \"true\" && echo \"--oom-kill-disable\")", strconv.Quote(*v)))
+			cmd.Args = append(cmd.Args, fmt.Sprintf("$(%s && echo \"--oom-kill-disable\")", *v))
 		}
 	}
 	if v := option.OOMScoreAdj; v != nil {
@@ -337,7 +337,7 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		if *v == "true" {
 			cmd.Args = append(cmd.Args, "--privileged")
 		} else {
-			cmd.Args = append(cmd.Args, fmt.Sprintf("$(test %s = \"true\" && echo \"--privileged\")", strconv.Quote(*v)))
+			cmd.Args = append(cmd.Args, fmt.Sprintf("$(%s && echo \"--privileged\")", *v))
 		}
 	}
 	for _, v := range option.Publish {
@@ -347,14 +347,14 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		if *v == "true" {
 			cmd.Args = append(cmd.Args, "--publish-all")
 		} else {
-			cmd.Args = append(cmd.Args, fmt.Sprintf("$(test %s = \"true\" && echo \"--publish-all\")", strconv.Quote(*v)))
+			cmd.Args = append(cmd.Args, fmt.Sprintf("$(%s && echo \"--publish-all\")", *v))
 		}
 	}
 	if v := option.ReadOnly; v != nil && *v != "false" {
 		if *v == "true" {
 			cmd.Args = append(cmd.Args, "--readonly")
 		} else {
-			cmd.Args = append(cmd.Args, fmt.Sprintf("$(test %s = \"true\" && echo \"--readonly\")", strconv.Quote(*v)))
+			cmd.Args = append(cmd.Args, fmt.Sprintf("$(%s && echo \"--readonly\")", *v))
 		}
 	}
 	if v := option.Restart; v != nil {
@@ -364,7 +364,7 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		if *v == "true" {
 			cmd.Args = append(cmd.Args, "--rm")
 		} else {
-			cmd.Args = append(cmd.Args, fmt.Sprintf("$(test %s = \"true\" && echo \"--rm\")", strconv.Quote(*v)))
+			cmd.Args = append(cmd.Args, fmt.Sprintf("$(%s && echo \"--rm\")", *v))
 		}
 	}
 	if v := option.Runtime; v != nil {
@@ -380,7 +380,7 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		if *v == "true" {
 			cmd.Args = append(cmd.Args, "--sig-proxy")
 		} else {
-			cmd.Args = append(cmd.Args, fmt.Sprintf("$(test %s = \"true\" && echo \"--sig-proxy\")", strconv.Quote(*v)))
+			cmd.Args = append(cmd.Args, fmt.Sprintf("$(%s && echo \"--sig-proxy\")", *v))
 		}
 	}
 	if v := option.StopSignal; v != nil {
@@ -402,7 +402,7 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		if *v == "true" {
 			cmd.Args = append(cmd.Args, "--tty")
 		} else {
-			cmd.Args = append(cmd.Args, fmt.Sprintf("$(test %s = \"true\" && echo \"--tty\")", strconv.Quote(*v)))
+			cmd.Args = append(cmd.Args, fmt.Sprintf("$(%s && echo \"--tty\")", *v))
 		}
 	}
 	for k, v := range option.Ulimit {

--- a/test/integration/dependencies/alpine
+++ b/test/integration/dependencies/alpine
@@ -5,9 +5,9 @@ if [ ! -f "${DOCKER_BINARY_PATH}" ]; then
   docker run --entrypoint '' -v [HOME]/.aliases/docker:/share docker:18.09.0 sh -c 'cp -av $(which docker) /share/docker-18-09-0' >/dev/null
 fi
 if [ -p /dev/stdin ]; then
-  cat - | docker run --env ALIASES_PWD="${ALIASES_PWD:-$PWD}" --interactive --network "host" --privileged --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") --volume "[HOME]/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --volume "[HOME]/.aliases:[HOME]/.aliases" --volume "${DOCKER_BINARY_PATH}:/usr/local/bin/docker" --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "[TEMP_DIR]/kubectl:/usr/local/bin/kubectl" --workdir "/kube" alpine:${ALPINE_VERSION:-"3.8"} "$@"
+  cat - | docker run --env ALIASES_PWD="${ALIASES_PWD:-$PWD}" --interactive --network "host" --privileged --rm $(tty >/dev/null && echo "--tty") --volume "[HOME]/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --volume "[HOME]/.aliases:[HOME]/.aliases" --volume "${DOCKER_BINARY_PATH}:/usr/local/bin/docker" --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "[TEMP_DIR]/kubectl:/usr/local/bin/kubectl" --workdir "/kube" alpine:${ALPINE_VERSION:-"3.8"} "$@"
   exit $?
 else
-  echo "" >/dev/null | docker run --env ALIASES_PWD="${ALIASES_PWD:-$PWD}" --interactive --network "host" --privileged --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") --volume "[HOME]/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --volume "[HOME]/.aliases:[HOME]/.aliases" --volume "${DOCKER_BINARY_PATH}:/usr/local/bin/docker" --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "[TEMP_DIR]/kubectl:/usr/local/bin/kubectl" --workdir "/kube" alpine:${ALPINE_VERSION:-"3.8"} "$@"
+  echo "" >/dev/null | docker run --env ALIASES_PWD="${ALIASES_PWD:-$PWD}" --interactive --network "host" --privileged --rm $(tty >/dev/null && echo "--tty") --volume "[HOME]/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --volume "[HOME]/.aliases:[HOME]/.aliases" --volume "${DOCKER_BINARY_PATH}:/usr/local/bin/docker" --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "[TEMP_DIR]/kubectl:/usr/local/bin/kubectl" --workdir "/kube" alpine:${ALPINE_VERSION:-"3.8"} "$@"
   exit $?
 fi

--- a/test/integration/dependencies/kubectl
+++ b/test/integration/dependencies/kubectl
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 if [ -p /dev/stdin ]; then
-  cat - | docker run --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") --volume "[HOME]/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --workdir "/kube" chatwork/kubectl:${KUBECTL_VERSION:-"1.11.2"} "$@"
+  cat - | docker run --interactive --network "host" --rm $(tty >/dev/null && echo "--tty") --volume "[HOME]/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --workdir "/kube" chatwork/kubectl:${KUBECTL_VERSION:-"1.11.2"} "$@"
   exit $?
 else
-  echo "" >/dev/null | docker run --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") --volume "[HOME]/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --workdir "/kube" chatwork/kubectl:${KUBECTL_VERSION:-"1.11.2"} "$@"
+  echo "" >/dev/null | docker run --interactive --network "host" --rm $(tty >/dev/null && echo "--tty") --volume "[HOME]/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --workdir "/kube" chatwork/kubectl:${KUBECTL_VERSION:-"1.11.2"} "$@"
   exit $?
 fi

--- a/test/integration/docker-binary/ubuntu
+++ b/test/integration/docker-binary/ubuntu
@@ -5,9 +5,9 @@ if [ ! -f "${DOCKER_BINARY_PATH}" ]; then
   docker run --entrypoint '' -v [HOME]/.aliases/docker:/share docker:18.09.0 sh -c 'cp -av $(which docker) /share/docker-18-09-0' >/dev/null
 fi
 if [ -p /dev/stdin ]; then
-  cat - | docker run --env ALIASES_PWD="${ALIASES_PWD:-$PWD}" --interactive --network "host" --privileged --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") --volume "[HOME]/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --volume "[HOME]/.aliases:[HOME]/.aliases" --volume "${DOCKER_BINARY_PATH}:/usr/local/bin/docker" --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "[TEMP_DIR]/kubectl:/usr/local/bin/kubectl" --workdir "/kube" amd64/ubuntu:${UBUNTU_VERSION:-"19.04"} "$@"
+  cat - | docker run --env ALIASES_PWD="${ALIASES_PWD:-$PWD}" --interactive --network "host" --privileged --rm $(tty >/dev/null && echo "--tty") --volume "[HOME]/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --volume "[HOME]/.aliases:[HOME]/.aliases" --volume "${DOCKER_BINARY_PATH}:/usr/local/bin/docker" --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "[TEMP_DIR]/kubectl:/usr/local/bin/kubectl" --workdir "/kube" amd64/ubuntu:${UBUNTU_VERSION:-"19.04"} "$@"
   exit $?
 else
-  echo "" >/dev/null | docker run --env ALIASES_PWD="${ALIASES_PWD:-$PWD}" --interactive --network "host" --privileged --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") --volume "[HOME]/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --volume "[HOME]/.aliases:[HOME]/.aliases" --volume "${DOCKER_BINARY_PATH}:/usr/local/bin/docker" --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "[TEMP_DIR]/kubectl:/usr/local/bin/kubectl" --workdir "/kube" amd64/ubuntu:${UBUNTU_VERSION:-"19.04"} "$@"
+  echo "" >/dev/null | docker run --env ALIASES_PWD="${ALIASES_PWD:-$PWD}" --interactive --network "host" --privileged --rm $(tty >/dev/null && echo "--tty") --volume "[HOME]/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --volume "[HOME]/.aliases:[HOME]/.aliases" --volume "${DOCKER_BINARY_PATH}:/usr/local/bin/docker" --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "[TEMP_DIR]/kubectl:/usr/local/bin/kubectl" --workdir "/kube" amd64/ubuntu:${UBUNTU_VERSION:-"19.04"} "$@"
   exit $?
 fi

--- a/test/integration/expand-env/alpine
+++ b/test/integration/expand-env/alpine
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 if [ -p /dev/stdin ]; then
-  cat - | docker run --env ${ALIASES_PWD:-$PWD}="$PWD" --interactive --label [HOME]="$HOME" --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") --ulimit $(echo nofile)="$(ulimit -n)" --user "root:$USER" --volume "${ALIASES_PWD:-$PWD}:$PWD" --volume "[HOME]:$HOME" --volume "$(echo $HOME):$(echo $HOME)" alpine:${ALPINE_VERSION:-"3.8"} "$@"
+  cat - | docker run --env ${ALIASES_PWD:-$PWD}="$PWD" --interactive --label [HOME]="$HOME" --network "host" --rm $(tty >/dev/null && echo "--tty") --ulimit $(echo nofile)="$(ulimit -n)" --user "root:$USER" --volume "${ALIASES_PWD:-$PWD}:$PWD" --volume "[HOME]:$HOME" --volume "$(echo $HOME):$(echo $HOME)" alpine:${ALPINE_VERSION:-"3.8"} "$@"
   exit $?
 else
-  echo "" >/dev/null | docker run --env ${ALIASES_PWD:-$PWD}="$PWD" --interactive --label [HOME]="$HOME" --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") --ulimit $(echo nofile)="$(ulimit -n)" --user "root:$USER" --volume "${ALIASES_PWD:-$PWD}:$PWD" --volume "[HOME]:$HOME" --volume "$(echo $HOME):$(echo $HOME)" alpine:${ALPINE_VERSION:-"3.8"} "$@"
+  echo "" >/dev/null | docker run --env ${ALIASES_PWD:-$PWD}="$PWD" --interactive --label [HOME]="$HOME" --network "host" --rm $(tty >/dev/null && echo "--tty") --ulimit $(echo nofile)="$(ulimit -n)" --user "root:$USER" --volume "${ALIASES_PWD:-$PWD}:$PWD" --volume "[HOME]:$HOME" --volume "$(echo $HOME):$(echo $HOME)" alpine:${ALPINE_VERSION:-"3.8"} "$@"
   exit $?
 fi

--- a/test/integration/pipe/alpine
+++ b/test/integration/pipe/alpine
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 if [ -p /dev/stdin ]; then
-  cat - | docker run --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") alpine:${ALPINE_VERSION:-"3.8"} "$@"
+  cat - | docker run --interactive --network "host" --rm $(tty >/dev/null && echo "--tty") alpine:${ALPINE_VERSION:-"3.8"} "$@"
   exit $?
 else
-  echo "" >/dev/null | docker run --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") alpine:${ALPINE_VERSION:-"3.8"} "$@"
+  echo "" >/dev/null | docker run --interactive --network "host" --rm $(tty >/dev/null && echo "--tty") alpine:${ALPINE_VERSION:-"3.8"} "$@"
   exit $?
 fi

--- a/test/integration/recursive-schema/alpine1
+++ b/test/integration/recursive-schema/alpine1
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 if [ -p /dev/stdin ]; then
-  cat - | docker run --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") alpine:${ALPINE1_VERSION:-"3.8"} "$@"
+  cat - | docker run --interactive --network "host" --rm $(tty >/dev/null && echo "--tty") alpine:${ALPINE1_VERSION:-"3.8"} "$@"
   exit $?
 else
-  echo "" >/dev/null | docker run --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") alpine:${ALPINE1_VERSION:-"3.8"} "$@"
+  echo "" >/dev/null | docker run --interactive --network "host" --rm $(tty >/dev/null && echo "--tty") alpine:${ALPINE1_VERSION:-"3.8"} "$@"
   exit $?
 fi

--- a/test/integration/recursive-schema/alpine2
+++ b/test/integration/recursive-schema/alpine2
@@ -5,9 +5,9 @@ if [ ! -f "${DOCKER_BINARY_PATH}" ]; then
   docker run --entrypoint '' -v [HOME]/.aliases/docker:/share docker:18.09.0 sh -c 'cp -av $(which docker) /share/docker-18-09-0' >/dev/null
 fi
 if [ -p /dev/stdin ]; then
-  cat - | docker run --env FOO="${FOO}" --env ALIASES_PWD="${ALIASES_PWD:-$PWD}" --interactive --network "host" --privileged --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") --volume "[HOME]/.aliases:[HOME]/.aliases" --volume "${DOCKER_BINARY_PATH}:/usr/local/bin/docker" --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "[TEMP_DIR]/alpine1:/usr/local/bin/alpine1" --volume "[TEMP_DIR]/4d89908fa7d1581bb3aaa1558f57ce08/alpine3:/usr/local/bin/alpine3" alpine:${ALPINE2_VERSION:-"3.8"} "$@"
+  cat - | docker run --env FOO="${FOO}" --env ALIASES_PWD="${ALIASES_PWD:-$PWD}" --interactive --network "host" --privileged --rm $(tty >/dev/null && echo "--tty") --volume "[HOME]/.aliases:[HOME]/.aliases" --volume "${DOCKER_BINARY_PATH}:/usr/local/bin/docker" --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "[TEMP_DIR]/alpine1:/usr/local/bin/alpine1" --volume "[TEMP_DIR]/4d89908fa7d1581bb3aaa1558f57ce08/alpine3:/usr/local/bin/alpine3" alpine:${ALPINE2_VERSION:-"3.8"} "$@"
   exit $?
 else
-  echo "" >/dev/null | docker run --env FOO="${FOO}" --env ALIASES_PWD="${ALIASES_PWD:-$PWD}" --interactive --network "host" --privileged --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") --volume "[HOME]/.aliases:[HOME]/.aliases" --volume "${DOCKER_BINARY_PATH}:/usr/local/bin/docker" --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "[TEMP_DIR]/alpine1:/usr/local/bin/alpine1" --volume "[TEMP_DIR]/4d89908fa7d1581bb3aaa1558f57ce08/alpine3:/usr/local/bin/alpine3" alpine:${ALPINE2_VERSION:-"3.8"} "$@"
+  echo "" >/dev/null | docker run --env FOO="${FOO}" --env ALIASES_PWD="${ALIASES_PWD:-$PWD}" --interactive --network "host" --privileged --rm $(tty >/dev/null && echo "--tty") --volume "[HOME]/.aliases:[HOME]/.aliases" --volume "${DOCKER_BINARY_PATH}:/usr/local/bin/docker" --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "[TEMP_DIR]/alpine1:/usr/local/bin/alpine1" --volume "[TEMP_DIR]/4d89908fa7d1581bb3aaa1558f57ce08/alpine3:/usr/local/bin/alpine3" alpine:${ALPINE2_VERSION:-"3.8"} "$@"
   exit $?
 fi

--- a/test/integration/recursive-schema/kubectl
+++ b/test/integration/recursive-schema/kubectl
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 if [ -p /dev/stdin ]; then
-  cat - | docker run --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") --volume "[HOME]/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --workdir "/kube" chatwork/kubectl:${KUBECTL_VERSION:-"1.11.2"} "$@"
+  cat - | docker run --interactive --network "host" --rm $(tty >/dev/null && echo "--tty") --volume "[HOME]/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --workdir "/kube" chatwork/kubectl:${KUBECTL_VERSION:-"1.11.2"} "$@"
   exit $?
 else
-  echo "" >/dev/null | docker run --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") --volume "[HOME]/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --workdir "/kube" chatwork/kubectl:${KUBECTL_VERSION:-"1.11.2"} "$@"
+  echo "" >/dev/null | docker run --interactive --network "host" --rm $(tty >/dev/null && echo "--tty") --volume "[HOME]/.kube:/root/.kube" --volume "${ALIASES_PWD:-$PWD}:/kube" --workdir "/kube" chatwork/kubectl:${KUBECTL_VERSION:-"1.11.2"} "$@"
   exit $?
 fi

--- a/test/integration/simple/sh
+++ b/test/integration/simple/sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 if [ -p /dev/stdin ]; then
-  cat - | docker run --entrypoint "sh" --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") alpine:${SH_VERSION:-"3.8"} -c "$@"
+  cat - | docker run --entrypoint "sh" --interactive --network "host" --rm $(tty >/dev/null && echo "--tty") alpine:${SH_VERSION:-"3.8"} -c "$@"
   exit $?
 else
-  echo "" >/dev/null | docker run --entrypoint "sh" --interactive --network "host" --rm $(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty") alpine:${SH_VERSION:-"3.8"} -c "$@"
+  echo "" >/dev/null | docker run --entrypoint "sh" --interactive --network "host" --rm $(tty >/dev/null && echo "--tty") alpine:${SH_VERSION:-"3.8"} -c "$@"
   exit $?
 fi


### PR DESCRIPTION
The execute expansion of the boolean parameter is a long string.
```
$(test "$(if tty >/dev/null; then echo true; else echo false; fi)" = "true" && echo "--tty")
```

Since it lowers the readability, I made it a short string.
```
$(tty >/dev/null && echo "--tty")
```
