### PR TITLE
fix: overridden with an empty string in aliases run

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -37,6 +37,9 @@ func stringFlag(c *cli.Context, name string) *string {
 		n = strings.Trim(n, " \t")
 		if c.IsSet(n) {
 			val := c.String(n)
+			if val == "" {
+				val = "''"
+			}
 			return &val
 		}
 	}
@@ -48,7 +51,14 @@ func sliceFlag(c *cli.Context, name string) []string {
 	for _, n := range strings.Split(name, ",") {
 		n = strings.Trim(n, " \t")
 		if c.IsSet(n) {
-			return c.StringSlice(n)
+			val := make([]string, 0)
+			for _, v := range c.StringSlice(n) {
+				if v == "" {
+					v = "''"
+				}
+				val = append(val, v)
+			}
+			return val
 		}
 	}
 	return nil
@@ -62,6 +72,9 @@ func mapFlag(c *cli.Context, name string) map[string]string {
 			val := map[string]string{}
 			for _, v := range c.StringSlice(n) {
 				s := strings.Split(v, "=")
+				if len(s) != 2 {
+					continue
+				}
 				val[s[0]] = strings.Join(s[1:], "=")
 			}
 			return val
@@ -320,7 +333,6 @@ func RunAction(c *cli.Context) error {
 	}
 
 	cmd := script.NewScript(*option)
-
 	if err := cmd.Run(client, args, opt); err != nil {
 		return err
 	}

--- a/pkg/aliases/script/docker.go
+++ b/pkg/aliases/script/docker.go
@@ -145,10 +145,11 @@ func (adpt *DockerRunAdapter) Command(client *docker.Client, overrideArgs []stri
 	if len(overrideArgs) > 0 {
 		args = overrideArgs
 	}
-	opt := overrideOption
-	if err := mergo.Merge(&opt, adpt.Option(), mergo.WithAppendSlice); err != nil {
+	dst := overrideOption
+	if err := mergo.Merge(&dst, *adpt.Option(), mergo.WithAppendSlice); err != nil {
 		panic(err)
 	}
+	opt := dst
 
 	opt.AddHost = util.UniqueStringSlice(opt.AddHost)
 	opt.BlkioWeightDevice = util.UniqueStringSlice(opt.BlkioWeightDevice)

--- a/pkg/aliases/script/script.go
+++ b/pkg/aliases/script/script.go
@@ -72,6 +72,18 @@ func (script *Script) Alias(client *docker.Client) (*posix.Cmd, error) {
 
 // Run aliases script.
 func (script *Script) Run(client *docker.Client, overrideArgs []string, overrideOption docker.RunOption) error {
+	targetPath := filepath.Join(context.ExportPath(), script.spec.Namespace(), script.spec.Path.Base())
+
+	if err := os.MkdirAll(path.Dir(targetPath), 0755); err != nil {
+		return err
+	}
+
+	fp, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0755) // set lock
+	if err != nil {
+		return nil
+	}
+	defer fp.Close()
+
 	shell := adaptShell(script.spec)
 	cmd, err := shell.Command(client, overrideArgs, overrideOption, logger.LogLevel() == logger.DebugLevel)
 	if err != nil {

--- a/pkg/docker/run.go
+++ b/pkg/docker/run.go
@@ -10,6 +10,16 @@ import (
 	"github.com/k-kinzal/aliases/pkg/posix"
 )
 
+func quote(s string) string {
+	length := len(s)
+	if length >= 2 && (s[0] == '"' || s[0] == '\'') {
+		if s[length-1] == '"' || s[length-1] == '\'' {
+			s = s[1 : length-1]
+		}
+	}
+	return strconv.Quote(s)
+}
+
 // RunOption is an option for executing docker run.
 type RunOption struct {
 	AddHost             []string
@@ -111,52 +121,52 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 	cmd := posix.Command(client.path, "run")
 
 	for _, v := range option.AddHost {
-		cmd.Args = append(cmd.Args, "--add-host", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--add-host", quote(v))
 	}
 	for _, v := range option.Attach {
-		cmd.Args = append(cmd.Args, "--attach", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--attach", quote(v))
 	}
 	if v := option.BlkioWeight; v != nil {
-		cmd.Args = append(cmd.Args, "--blkio-weight", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--blkio-weight", quote(*v))
 	}
 	for _, v := range option.BlkioWeightDevice {
-		cmd.Args = append(cmd.Args, "--blkio-weight-device", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--blkio-weight-device", quote(v))
 	}
 	for _, v := range option.CapAdd {
-		cmd.Args = append(cmd.Args, fmt.Sprintf("--cap-add=%s", strconv.Quote(v)))
+		cmd.Args = append(cmd.Args, fmt.Sprintf("--cap-add=%s", quote(v)))
 	}
 	for _, v := range option.CapDrop {
-		cmd.Args = append(cmd.Args, fmt.Sprintf("--cap-drop=%s", strconv.Quote(v)))
+		cmd.Args = append(cmd.Args, fmt.Sprintf("--cap-drop=%s", quote(v)))
 	}
 	if v := option.CgroupParent; v != nil {
-		cmd.Args = append(cmd.Args, fmt.Sprintf("--cgroup-parent==%s", strconv.Quote(*v)))
+		cmd.Args = append(cmd.Args, fmt.Sprintf("--cgroup-parent==%s", quote(*v)))
 	}
 	if v := option.CIDFile; v != nil {
-		cmd.Args = append(cmd.Args, "--cidfile", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--cidfile", quote(*v))
 	}
 	if v := option.CPUPeriod; v != nil {
-		cmd.Args = append(cmd.Args, "--cpu-period", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--cpu-period", quote(*v))
 	}
 	if v := option.CPUQuota; v != nil {
-		cmd.Args = append(cmd.Args, "--cpu-quota", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--cpu-quota", quote(*v))
 	}
 	if v := option.CPURtPeriod; v != nil {
-		cmd.Args = append(cmd.Args, "--cpu-rt-period", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--cpu-rt-period", quote(*v))
 	}
 	if v := option.CPURtRuntime; v != nil {
-		cmd.Args = append(cmd.Args, "--cpu-rt-runtime", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--cpu-rt-runtime", quote(*v))
 	}
 	if v := option.CPUShares; v != nil {
-		cmd.Args = append(cmd.Args, "--cpu-shares", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--cpu-shares", quote(*v))
 	}
 	if v := option.CPUs; v != nil {
-		cmd.Args = append(cmd.Args, "--cpus", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--cpus", quote(*v))
 	}
 	if v := option.CPUsetCPUs; v != nil {
-		cmd.Args = append(cmd.Args, "--cpuset-cpus", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--cpuset-cpus", quote(*v))
 	}
 	if v := option.CPUsetMems; v != nil {
-		cmd.Args = append(cmd.Args, "--cpuset-mems", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--cpuset-mems", quote(*v))
 	}
 	if v := option.Detach; v != nil && *v != "false" {
 		if *v == "true" {
@@ -166,25 +176,25 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		}
 	}
 	if v := option.DetachKeys; v != nil {
-		cmd.Args = append(cmd.Args, "--detach-keys", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--detach-keys", quote(*v))
 	}
 	for _, v := range option.Device {
-		cmd.Args = append(cmd.Args, "--device", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--device", quote(v))
 	}
 	for _, v := range option.DeviceCgroupRule {
-		cmd.Args = append(cmd.Args, "--device-cgroup-rule", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--device-cgroup-rule", quote(v))
 	}
 	for _, v := range option.DeviceReadBPS {
-		cmd.Args = append(cmd.Args, "--device-read-bps", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--device-read-bps", quote(v))
 	}
 	for _, v := range option.DeviceReadIOPS {
-		cmd.Args = append(cmd.Args, "--device-read-iops", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--device-read-iops", quote(v))
 	}
 	for _, v := range option.DeviceWriteBPS {
-		cmd.Args = append(cmd.Args, "--device-write-bps", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--device-write-bps", quote(v))
 	}
 	for _, v := range option.DeviceWriteIOPS {
-		cmd.Args = append(cmd.Args, "--device-write-iops", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--device-write-iops", quote(v))
 	}
 	if v := option.DisableContentTrust; v != nil && *v != "false" {
 		if *v == "true" {
@@ -194,46 +204,46 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		}
 	}
 	for _, v := range option.DNS {
-		cmd.Args = append(cmd.Args, "--dns", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--dns", quote(v))
 	}
 	for _, v := range option.DNSOption {
-		cmd.Args = append(cmd.Args, "--dns-option", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--dns-option", quote(v))
 	}
 	for _, v := range option.DNSSearch {
-		cmd.Args = append(cmd.Args, "--dns-search", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--dns-search", quote(v))
 	}
 	if v := option.Entrypoint; v != nil {
-		cmd.Args = append(cmd.Args, "--entrypoint", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--entrypoint", quote(*v))
 	}
 	for _, k := range util.StringKeys(option.Env) {
-		cmd.Args = append(cmd.Args, "--env", fmt.Sprintf("%s=%s", k, strconv.Quote(option.Env[k])))
+		cmd.Args = append(cmd.Args, "--env", fmt.Sprintf("%s=%s", k, quote(option.Env[k])))
 	}
 	for _, v := range option.EnvFile {
-		cmd.Args = append(cmd.Args, "--env-file", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--env-file", quote(v))
 	}
 	for _, v := range option.Expose {
-		cmd.Args = append(cmd.Args, "--expose", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--expose", quote(v))
 	}
 	for _, v := range option.GroupAdd {
-		cmd.Args = append(cmd.Args, "--group-add", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--group-add", quote(v))
 	}
 	if v := option.HealthCmd; v != nil {
-		cmd.Args = append(cmd.Args, "--health-cmd", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--health-cmd", quote(*v))
 	}
 	if v := option.HealthInterval; v != nil {
-		cmd.Args = append(cmd.Args, "--health-interval", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--health-interval", quote(*v))
 	}
 	if v := option.HealthRetries; v != nil {
-		cmd.Args = append(cmd.Args, "--health-retries", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--health-retries", quote(*v))
 	}
 	if v := option.HealthStartPeriod; v != nil {
-		cmd.Args = append(cmd.Args, "--health-start-period", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--health-start-period", quote(*v))
 	}
 	if v := option.HealthTimeout; v != nil {
-		cmd.Args = append(cmd.Args, "--health-timeout", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--health-timeout", quote(*v))
 	}
 	if v := option.Hostname; v != nil {
-		cmd.Args = append(cmd.Args, "--hostname", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--hostname", quote(*v))
 	}
 	if v := option.Init; v != nil && *v != "false" {
 		if *v == "true" {
@@ -250,64 +260,64 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		}
 	}
 	if v := option.IP; v != nil {
-		cmd.Args = append(cmd.Args, "--ip", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--ip", quote(*v))
 	}
 	if v := option.IP; v != nil {
-		cmd.Args = append(cmd.Args, "--ip6", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--ip6", quote(*v))
 	}
 	if v := option.IPC; v != nil {
-		cmd.Args = append(cmd.Args, "--ipc", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--ipc", quote(*v))
 	}
 	if v := option.Isolation; v != nil {
-		cmd.Args = append(cmd.Args, "--isolation", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--isolation", quote(*v))
 	}
 	if v := option.KernelMemory; v != nil {
-		cmd.Args = append(cmd.Args, "--kernel-memory", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--kernel-memory", quote(*v))
 	}
 	for _, k := range util.StringKeys(option.Label) {
-		cmd.Args = append(cmd.Args, "--label", fmt.Sprintf("%s=%s", k, strconv.Quote(option.Label[k])))
+		cmd.Args = append(cmd.Args, "--label", fmt.Sprintf("%s=%s", k, quote(option.Label[k])))
 	}
 	for _, v := range option.LabelFile {
-		cmd.Args = append(cmd.Args, "--label-file", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--label-file", quote(v))
 	}
 	for _, v := range option.Link {
-		cmd.Args = append(cmd.Args, "--link", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--link", quote(v))
 	}
 	for _, v := range option.LinkLocalIP {
-		cmd.Args = append(cmd.Args, "--link-loal-ip", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--link-loal-ip", quote(v))
 	}
 	if v := option.LogDriver; v != nil {
-		cmd.Args = append(cmd.Args, "--log-driver", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--log-driver", quote(*v))
 	}
 	for _, k := range util.StringKeys(option.LogOpt) {
-		cmd.Args = append(cmd.Args, "--log-opt", fmt.Sprintf("%s=%s", k, strconv.Quote(option.LogOpt[k])))
+		cmd.Args = append(cmd.Args, "--log-opt", fmt.Sprintf("%s=%s", k, quote(option.LogOpt[k])))
 	}
 	if v := option.MacAddress; v != nil {
-		cmd.Args = append(cmd.Args, "--mac-address", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--mac-address", quote(*v))
 	}
 	if v := option.Memory; v != nil {
-		cmd.Args = append(cmd.Args, "--memory", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--memory", quote(*v))
 	}
 	if v := option.MemoryReservation; v != nil {
-		cmd.Args = append(cmd.Args, "--memory-reservation", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--memory-reservation", quote(*v))
 	}
 	if v := option.MemorySwap; v != nil {
-		cmd.Args = append(cmd.Args, "--memory-swap", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--memory-swap", quote(*v))
 	}
 	if v := option.MemorySwappiness; v != nil {
-		cmd.Args = append(cmd.Args, "--memory-swappiness", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--memory-swappiness", quote(*v))
 	}
 	for _, k := range util.StringKeys(option.Mount) {
-		cmd.Args = append(cmd.Args, "--mount", fmt.Sprintf("%s=%s", k, strconv.Quote(option.Mount[k])))
+		cmd.Args = append(cmd.Args, "--mount", fmt.Sprintf("%s=%s", k, quote(option.Mount[k])))
 	}
 	if v := option.Name; v != nil {
-		cmd.Args = append(cmd.Args, "--name", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--name", quote(*v))
 	}
 	if v := option.Network; v != nil {
-		cmd.Args = append(cmd.Args, "--network", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--network", quote(*v))
 	}
 	for _, v := range option.NetworkAlias {
-		cmd.Args = append(cmd.Args, "--network-alias", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--network-alias", quote(v))
 	}
 	if v := option.NoHealthcheck; v != nil && *v != "false" {
 		if *v == "true" {
@@ -324,16 +334,16 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		}
 	}
 	if v := option.OOMScoreAdj; v != nil {
-		cmd.Args = append(cmd.Args, "--oom-secore-adj", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--oom-secore-adj", quote(*v))
 	}
 	if v := option.PID; v != nil {
-		cmd.Args = append(cmd.Args, "--pid", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--pid", quote(*v))
 	}
 	if v := option.PidsLimit; v != nil {
-		cmd.Args = append(cmd.Args, "--pids-limit", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--pids-limit", quote(*v))
 	}
 	if v := option.Platform; v != nil {
-		cmd.Args = append(cmd.Args, "--platform", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--platform", quote(*v))
 	}
 	if v := option.Privileged; v != nil && *v != "false" {
 		if *v == "true" {
@@ -343,7 +353,7 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		}
 	}
 	for _, v := range option.Publish {
-		cmd.Args = append(cmd.Args, "--publish", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--publish", quote(v))
 	}
 	if v := option.PublishAll; v != nil && *v != "false" {
 		if *v == "true" {
@@ -360,7 +370,7 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		}
 	}
 	if v := option.Restart; v != nil {
-		cmd.Args = append(cmd.Args, "--restart", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--restart", quote(*v))
 	}
 	if v := option.Rm; v != nil && *v != "false" {
 		if *v == "true" {
@@ -370,13 +380,13 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		}
 	}
 	if v := option.Runtime; v != nil {
-		cmd.Args = append(cmd.Args, "--runtime", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--runtime", quote(*v))
 	}
 	for _, k := range util.StringKeys(option.SecurityOpt) {
-		cmd.Args = append(cmd.Args, "--security-opt", fmt.Sprintf("%s=%s", k, strconv.Quote(option.SecurityOpt[k])))
+		cmd.Args = append(cmd.Args, "--security-opt", fmt.Sprintf("%s=%s", k, quote(option.SecurityOpt[k])))
 	}
 	if v := option.ShmSize; v != nil {
-		cmd.Args = append(cmd.Args, "--shm-size", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--shm-size", quote(*v))
 	}
 	if v := option.SigProxy; v != nil && *v != "false" {
 		if *v == "true" {
@@ -386,19 +396,19 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		}
 	}
 	if v := option.StopSignal; v != nil {
-		cmd.Args = append(cmd.Args, "--stop-signal", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--stop-signal", quote(*v))
 	}
 	if v := option.StopTimeout; v != nil {
-		cmd.Args = append(cmd.Args, "--stop-timeout", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--stop-timeout", quote(*v))
 	}
 	for _, k := range util.StringKeys(option.StorageOpt) {
-		cmd.Args = append(cmd.Args, "--storage-opt", fmt.Sprintf("%s=%s", k, strconv.Quote(option.StorageOpt[k])))
+		cmd.Args = append(cmd.Args, "--storage-opt", fmt.Sprintf("%s=%s", k, quote(option.StorageOpt[k])))
 	}
 	for _, k := range util.StringKeys(option.Sysctl) {
-		cmd.Args = append(cmd.Args, "--sysctl", fmt.Sprintf("%s=%s", k, strconv.Quote(option.Sysctl[k])))
+		cmd.Args = append(cmd.Args, "--sysctl", fmt.Sprintf("%s=%s", k, quote(option.Sysctl[k])))
 	}
 	for _, v := range option.Tmpfs {
-		cmd.Args = append(cmd.Args, "--tmpfs", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--tmpfs", quote(v))
 	}
 	if v := option.TTY; v != nil && *v != "false" {
 		if *v == "true" {
@@ -408,38 +418,38 @@ func (client *Client) Run(image string, args []string, option RunOption) *posix.
 		}
 	}
 	for _, k := range util.StringKeys(option.Ulimit) {
-		cmd.Args = append(cmd.Args, "--ulimit", fmt.Sprintf("%s=%s", k, strconv.Quote(option.Ulimit[k])))
+		cmd.Args = append(cmd.Args, "--ulimit", fmt.Sprintf("%s=%s", k, quote(option.Ulimit[k])))
 	}
 	if v := option.User; v != nil {
-		cmd.Args = append(cmd.Args, "--user", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--user", quote(*v))
 	}
 	if v := option.Userns; v != nil {
-		cmd.Args = append(cmd.Args, "--userns", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--userns", quote(*v))
 	}
 	if v := option.UTS; v != nil {
-		cmd.Args = append(cmd.Args, "--uts", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--uts", quote(*v))
 	}
 	for _, v := range option.Volume {
-		cmd.Args = append(cmd.Args, "--volume", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--volume", quote(v))
 	}
 	if v := option.VolumeDriver; v != nil {
-		cmd.Args = append(cmd.Args, "--volume-driver", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--volume-driver", quote(*v))
 	}
 	for _, v := range option.VolumesFrom {
-		cmd.Args = append(cmd.Args, "--volumes-from", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--volumes-from", quote(v))
 	}
 	if v := option.Workdir; v != nil {
-		cmd.Args = append(cmd.Args, "--workdir", strconv.Quote(*v))
+		cmd.Args = append(cmd.Args, "--workdir", quote(*v))
 	}
 	for _, v := range option.VolumesFrom {
-		cmd.Args = append(cmd.Args, "--volumes-from", strconv.Quote(v))
+		cmd.Args = append(cmd.Args, "--volumes-from", quote(v))
 	}
 	cmd.Args = append(cmd.Args, image)
 	for _, v := range args {
 		if strings.HasPrefix(v, "'") && strings.HasSuffix(v, "'") {
 			cmd.Args = append(cmd.Args, v)
 		} else if strings.Contains(v, " ") {
-			cmd.Args = append(cmd.Args, strconv.Quote(v))
+			cmd.Args = append(cmd.Args, quote(v))
 		} else {
 			cmd.Args = append(cmd.Args, v)
 		}

--- a/test/integration/extend-entrypoint/test.sh
+++ b/test/integration/extend-entrypoint/test.sh
@@ -15,3 +15,5 @@ cat ${TEMP_DIR}/alpine | ${MASK} | ${DIFF} ${TEST_DIR}/alpine -
 
 ${TEMP_DIR}/alpine | ${DIFF} ${TEST_DIR}/stdout -
 ${ALIASES} run /usr/local/bin/alpine | ${MASK} | ${DIFF} ${TEST_DIR}/stdout -
+
+${ALIASES} run --entrypoint '' /usr/local/bin/alpine sh -c "echo 1" | ${MASK} | ${DIFF} ${TEST_DIR}/stdout -


### PR DESCRIPTION
```yaml
/usr/local/bin/alpine:
  image: alpine
  tag: latest
  entrypoint: |
    #!/bin/sh
    echo 111
```

```
$ aliases -v run --entrypoint '' /usr/local/bin/alpine sh -c "echo 1"
docker run --entrypoint "#!/bin/sh\necho 1\n" --interactive --network "host" --rm alpine:"3.8" sh -c "echo 1"
aliases: error response from daemon: OCI runtime create failed: container_linux.go:344: starting container process caused "exec: \"#!/bin/sh\\\\necho 1\\\\n\": stat #!/bin/sh\\necho 1\\n: no such file or directory": unknown.
```