### PR TITLE
fix: not inherit entrypoint

### DIFF
--- a/pkg/aliases/yaml/yaml.go
+++ b/pkg/aliases/yaml/yaml.go
@@ -124,6 +124,7 @@ func Unmarshal(buf []byte) (*Config, error) {
 			src.Image = ""
 			src.Args = nil
 			src.Tag = ""
+			src.Entrypoint = nil
 			src.Command = nil
 			if err := mergo.Map(&dst, src, mergo.WithAppendSlice); err != nil {
 				panic(err)
@@ -155,6 +156,7 @@ func Unmarshal(buf []byte) (*Config, error) {
 			src.Image = ""
 			src.Args = nil
 			src.Tag = ""
+			src.Entrypoint = nil
 			src.Command = nil
 			if err := mergo.Map(&dst, src, mergo.WithAppendSlice); err != nil {
 				panic(err)

--- a/test/integration/recursive-schema/aliases.yaml
+++ b/test/integration/recursive-schema/aliases.yaml
@@ -14,6 +14,7 @@
         - /usr/local/bin/alpine4:
             image: alpine
             tag: 3.8
+            entrypoint: echo
         - /usr/local/bin/alpine5:
             image: alpine
             tag: 3.8


### PR DESCRIPTION
```yaml
/path/to/command1:
  image: alpine
  tag: latest
  dependencies:
  - /path/to/command2:
      image: alpine
      tag: latest
      entrypoint: echo
```

```bash
$ aliases run /path/to/command1 sh -c "echo 1"
sh -c echo 1
```

It will not work by inheriting `entrypoint`.
Since there is no use case that I want to inherit `entrypoint`, do not inherit it.