### PR TITLE
Changes to be able to mount docker binary without dependencies

### DIFF
--- a/pkg/aliases/script/binary__test.go
+++ b/pkg/aliases/script/binary__test.go
@@ -14,10 +14,10 @@ import (
 func ExampleDockerBinaryAdapter_Image() {
 	spec := yaml.Option{
 		OptionSpec: &yaml.OptionSpec{
-			Docker: struct {
-				Image string `yaml:"image" default:"docker"`
-				Tag   string `yaml:"tag" default:"18.09.0"`
-			}{Image: "docker", Tag: "18.09.0"},
+			Docker: &yaml.DockerSpec{
+				Image: "docker",
+				Tag:   "18.09.0",
+			},
 		},
 	}
 	bin := script.AdaptDockerBinary(spec)
@@ -28,10 +28,10 @@ func ExampleDockerBinaryAdapter_Image() {
 func ExampleDockerBinaryAdapter_Tag() {
 	spec := yaml.Option{
 		OptionSpec: &yaml.OptionSpec{
-			Docker: struct {
-				Image string `yaml:"image" default:"docker"`
-				Tag   string `yaml:"tag" default:"18.09.0"`
-			}{Image: "docker", Tag: "18.09.0"},
+			Docker: &yaml.DockerSpec{
+				Image: "docker",
+				Tag:   "18.09.0",
+			},
 		},
 	}
 	bin := script.AdaptDockerBinary(spec)
@@ -42,10 +42,10 @@ func ExampleDockerBinaryAdapter_Tag() {
 func ExampleDockerBinaryAdapter_FileName() {
 	spec := yaml.Option{
 		OptionSpec: &yaml.OptionSpec{
-			Docker: struct {
-				Image string `yaml:"image" default:"docker"`
-				Tag   string `yaml:"tag" default:"18.09.0"`
-			}{Image: "docker", Tag: "18.09.0"},
+			Docker: &yaml.DockerSpec{
+				Image: "docker",
+				Tag:   "18.09.0",
+			},
 		},
 	}
 	bin := script.AdaptDockerBinary(spec)
@@ -66,10 +66,10 @@ func ExampleDockerBinaryAdapter_Command() {
 	}
 	spec := yaml.Option{
 		OptionSpec: &yaml.OptionSpec{
-			Docker: struct {
-				Image string `yaml:"image" default:"docker"`
-				Tag   string `yaml:"tag" default:"18.09.0"`
-			}{Image: "docker", Tag: "18.09.0"},
+			Docker: &yaml.DockerSpec{
+				Image: "docker",
+				Tag:   "18.09.0",
+			},
 		},
 	}
 	bin := script.AdaptDockerBinary(spec)

--- a/pkg/aliases/script/script_test.go
+++ b/pkg/aliases/script/script_test.go
@@ -73,10 +73,10 @@ func ExampleScript_WriteWithOverride() {
 	}
 	spec := yaml.Option{
 		OptionSpec: &yaml.OptionSpec{
-			Docker: struct {
-				Image string `yaml:"image" default:"docker"`
-				Tag   string `yaml:"tag" default:"18.09.0"`
-			}{Image: "docker", Tag: "18.09.0"},
+			Docker: &yaml.DockerSpec{
+				Image: "docker",
+				Tag:   "18.09.0",
+			},
 			Image: "alpine",
 			Tag:   "latest",
 			Args:  []string{"-c"},

--- a/pkg/aliases/script/shell__test.go
+++ b/pkg/aliases/script/shell__test.go
@@ -109,10 +109,10 @@ func ExampleShellAdapter_Command_hasDependencies() {
 	}
 	spec := yaml.Option{
 		OptionSpec: &yaml.OptionSpec{
-			Docker: struct {
-				Image string `yaml:"image" default:"docker"`
-				Tag   string `yaml:"tag" default:"18.09.0"`
-			}{Image: "docker", Tag: "18.09.0"},
+			Docker: &yaml.DockerSpec{
+				Image: "docker",
+				Tag:   "18.09.0",
+			},
 			Image:      "alpine",
 			Tag:        "latest",
 			Entrypoint: (func(str string) *string { return &str })("sh"),

--- a/pkg/aliases/yaml/config.go
+++ b/pkg/aliases/yaml/config.go
@@ -4,6 +4,12 @@ import (
 	"github.com/k-kinzal/aliases/pkg/types"
 )
 
+// DockerSpec is docker binary config to mount
+type DockerSpec struct {
+	Image string `yaml:"image" default:"docker"`
+	Tag   string `yaml:"tag" default:"18.09.0"`
+}
+
 // OptionSpec is the specification of option in aliases config
 //
 // ```
@@ -13,10 +19,7 @@ import (
 // ```
 type OptionSpec struct {
 	// binary settings
-	Docker struct {
-		Image string `yaml:"image" default:"docker"`
-		Tag   string `yaml:"tag" default:"18.09.0"`
-	} `yaml:"docker"`
+	Docker *DockerSpec
 	// docker run settings
 	Image   string   `yaml:"image" validate:"required"`
 	Tag     string   `yaml:"tag" validate:"required"`

--- a/pkg/aliases/yaml/yaml.go
+++ b/pkg/aliases/yaml/yaml.go
@@ -176,6 +176,13 @@ func Unmarshal(buf []byte) (*Config, error) {
 		if err := v.Struct(option.OptionSpec); err != nil {
 			return nil, Errorf("%s in `%s`", err, path)
 		}
+		if len(option.Dependencies) > 0 && option.Docker == nil {
+			dockerSpec := &DockerSpec{}
+			if err := defaults.Set(dockerSpec); err != nil {
+				panic(err)
+			}
+			option.Docker = dockerSpec
+		}
 		if err := defaults.Set(option.OptionSpec); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Change `aliases` dependency management from `dep` to `mod`.
The docker binary not be mounted because `dep` delete in `aliases.yaml` used in this project.
However, `aliases` fail the test because it depends on the docker binary.

Also, the docker binary expects always to mounted from the host, so it cannot use by specifying it to `dependencies` in `aliases.yaml`

**aliases.yaml**
``` yaml
/usr/local/bin/go:
  docker:
    image: docker
    tag: 18.09
  image: golang
  tag: 1.14
  command: go
  env:
    GOPATH: /go
  volume:
    - $PWD:/go/src/github.com/k-kinzal/aliases
  workdir: /go/src/github.com/k-kinzal/aliases
```

```
$ aliases -c aliases.yaml -v run --entrypoint '' /usr/local/bin/go sh -c 'make test'
docker run --entrypoint "" --env ALIASES_PWD="/go/src/github.com/k-kinzal/aliases" --env GOPATH="/go" --interactive --network "host" --privileged --rm "--tty" --volume "/.aliases:/.aliases" --volume ".aliases/docker/docker-18-09:/usr/local/bin/docker" --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "/go/src/github.com/k-kinzal/aliases:/go/src/github.com/k-kinzal/aliases" --workdir "/go/src/github.com/k-kinzal/aliases" golang:"1.13" sh -c "make test"
...
```

Even if the binary has no dependencies, if `docker` is specified, it is changed so that the docker binary of the host can be mounted.