### PR TITLE
Use hash of spec instead of config file path for temp file generation

### DIFF
--- a/pkg/aliases/context/context.go
+++ b/pkg/aliases/context/context.go
@@ -97,8 +97,8 @@ func BinaryPath() string {
 	return p
 }
 
-func TemporaryPath() string {
-	p := path.Join(HomePath(), "tmp", types.MD5(ConfPath()))
+func TemporaryPath(spec interface{}) string {
+	p := path.Join(HomePath(), "tmp", types.MD5(spec))
 	if _, err := os.Stat(p); os.IsNotExist(err) {
 		_ = makeDir(p)
 	}

--- a/pkg/aliases/script/shell.go
+++ b/pkg/aliases/script/shell.go
@@ -149,7 +149,7 @@ func (adpt *ShellAdapter) Command(client *docker.Client, overrideArgs []string, 
 		"dependencies":  len(spec.Dependencies) > 0,
 		"binary":        nil,
 		"debug":         debug,
-		"temporaryPath": context.TemporaryPath(),
+		"temporaryPath": context.TemporaryPath(spec),
 	}
 	if spec.Docker != nil {
 		data["binary"] = map[string]string{

--- a/test/integration/env-prefix/test.sh
+++ b/test/integration/env-prefix/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -eu
+set -euv
 
 TEMP_DIR=$(mktemp -d /tmp/XXXX)
 TEST_DIR="$(cd "$(dirname "${0}")"; echo "$(pwd)")"
@@ -15,7 +15,9 @@ export FOO_PASS_ENV3="3"
 
 ${ALIASES} gen --export-path "${TEMP_DIR}" | ${MASK} | sort | ${DIFF} ${TEST_DIR}/alias -
 ${ALIASES} gen --export --export-path "${TEMP_DIR}" | ${MASK} | ${DIFF} ${TEST_DIR}/export -
+cat ${TEMP_DIR}/alpine1
 cat ${TEMP_DIR}/alpine1 | ${MASK} | ${DIFF} ${TEST_DIR}/alpine1 -
+cat ${TEMP_DIR}/alpine2
 cat ${TEMP_DIR}/alpine2 | ${MASK} | ${DIFF} ${TEST_DIR}/alpine2 -
 
 ${TEMP_DIR}/alpine2 /bin/sh -c 'alpine1 sh -c "env"' | grep PASS_ENV | ${DIFF} ${TEST_DIR}/stdout -


### PR DESCRIPTION
#68 broke the usage of aliases as a go library. This brings it back by removing the runtime dependency to the config filem which does not always exit when aliases is used as a library.