### PR TITLE
Stop using hash of conf path for temp dir generation

### DIFF
--- a/pkg/aliases/context/context.go
+++ b/pkg/aliases/context/context.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-
-	"github.com/k-kinzal/aliases/pkg/types"
 )
 
 var (
@@ -98,7 +96,7 @@ func BinaryPath() string {
 }
 
 func TemporaryPath() string {
-	p := path.Join(HomePath(), "tmp", types.MD5(ConfPath()))
+	p := path.Join(HomePath(), "tmp")
 	if _, err := os.Stat(p); os.IsNotExist(err) {
 		_ = makeDir(p)
 	}

--- a/test/integration/env-prefix/test.sh
+++ b/test/integration/env-prefix/test.sh
@@ -7,7 +7,7 @@ TEST_DIR="$(cd "$(dirname "${0}")"; echo "$(pwd)")"
 
 ALIASES=$(cd "${TEST_DIR}/../../..//dist"; echo "$(pwd)/aliases -c ${TEST_DIR}/aliases.yaml")
 DIFF=$(if which colordiff >/dev/null; then echo "colordiff -Buw --strip-trailing-cr"; else echo "diff -Bw"; fi)
-MASK="sed -e s|${HOME}|[HOME]|g -e s|${TEMP_DIR}|[TEMP_DIR]|g -e s|\[HOME\]/.aliases/tmp/[a-z0-9]*|[ALIASE_TEMP_DIR]|"
+MASK="sed -e s|${HOME}|[HOME]|g -e s|${TEMP_DIR}|[TEMP_DIR]|g -e s|\[HOME\]/.aliases/tmp|[ALIASE_TEMP_DIR]|"
 
 export FOO_PASS_ENV1="1"
 export FOO_PASS_ENV2="2"


### PR DESCRIPTION
#68 broke the usage of aliases as a go library. This brings it back by removing the runtime dependency to the config filem which does not always exit when aliases is used as a library.

This is an alternative to #69